### PR TITLE
Add admin map tools for adding and editing course locations

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,4 +1,5 @@
 import bcrypt
+from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel, ConfigDict
 from starlette import status
@@ -28,6 +29,22 @@ class PasswordReset(BaseModel):
     new_password: str
 
 
+class CourseCreate(BaseModel):
+    club_name: str | None = None
+    course_name: str | None = None
+    address: str | None = None
+    city: str | None = None
+    state: str | None = None
+    country: str | None = None
+    latitude: float
+    longitude: float
+
+
+class LocationUpdate(BaseModel):
+    latitude: float
+    longitude: float
+
+
 @router.get("/")
 async def root(user: user_dependency):
     if user is None or user.get("role") != "admin":
@@ -51,6 +68,46 @@ async def delete_course(user: user_dependency, db: db_dependency, course_id: int
         raise HTTPException(status_code=404, detail="Course not found")
     db.delete(course_model)
     db.commit()
+
+
+@router.post("/courses", status_code=status.HTTP_201_CREATED, response_model=CourseBase)
+async def create_course(user: user_dependency, db: db_dependency, course_data: CourseCreate):
+    if user is None or user.get("role") != "admin":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    course = Courses(
+        club_name=course_data.club_name,
+        course_name=course_data.course_name,
+        address=course_data.address,
+        city=course_data.city,
+        state=course_data.state,
+        country=course_data.country,
+        latitude=course_data.latitude,
+        longitude=course_data.longitude,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(course)
+    db.commit()
+    db.refresh(course)
+    return course
+
+
+@router.put("/courses/{course_id}/location", status_code=status.HTTP_200_OK, response_model=CourseBase)
+async def update_course_location(
+    user: user_dependency,
+    db: db_dependency,
+    location: LocationUpdate,
+    course_id: int = Path(ge=1),
+):
+    if user is None or user.get("role") != "admin":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    course = db.query(Courses).filter(Courses.id == course_id).first()
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    course.latitude = location.latitude
+    course.longitude = location.longitude
+    db.commit()
+    db.refresh(course)
+    return course
 
 
 @router.get("/users", status_code=status.HTTP_200_OK, response_model=list[UserSummary])

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,7 +1,7 @@
 import bcrypt
 from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Path
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from starlette import status
 from app.models import Courses, Users
 from app.dependencies import db_dependency, user_dependency
@@ -36,13 +36,13 @@ class CourseCreate(BaseModel):
     city: str | None = None
     state: str | None = None
     country: str | None = None
-    latitude: float
-    longitude: float
+    latitude: float = Field(..., ge=-90.0, le=90.0)
+    longitude: float = Field(..., ge=-180.0, le=180.0)
 
 
 class LocationUpdate(BaseModel):
-    latitude: float
-    longitude: float
+    latitude: float = Field(..., ge=-90.0, le=90.0)
+    longitude: float = Field(..., ge=-180.0, le=180.0)
 
 
 @router.get("/")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,9 +15,11 @@
         "axios": "^1.13.2",
         "bootstrap": "^5.3.8",
         "js-cookie": "^3.0.5",
+        "leaflet": "^1.9.4",
         "react": "^19.2.3",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.3",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.11.0",
         "web-vitals": "^5.1.0"
       },
@@ -1176,6 +1178,17 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@react-types/shared": {
@@ -3559,6 +3572,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4082,6 +4101,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,9 +21,11 @@
     "axios": "^1.13.2",
     "bootstrap": "^5.3.8",
     "js-cookie": "^3.0.5",
+    "leaflet": "^1.9.4",
     "react": "^19.2.3",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.3",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.11.0",
     "web-vitals": "^5.1.0"
   },

--- a/frontend/src/components/AdminAddCourse.jsx
+++ b/frontend/src/components/AdminAddCourse.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -15,11 +15,15 @@ L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, 
 const EMPTY_FORM = { club_name: '', course_name: '', address: '', city: '', state: '', country: '' };
 
 function LocationPicker({ position, setPosition, setForm }) {
+    const abortRef = useRef(null);
     useMapEvents({
         click(e) {
             const { lat, lng } = e.latlng;
             setPosition([lat, lng]);
-            fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`)
+            if (abortRef.current) abortRef.current.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+            fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`, { signal: controller.signal })
                 .then(r => r.json())
                 .then(data => {
                     const a = data.address || {};
@@ -31,7 +35,7 @@ function LocationPicker({ position, setPosition, setForm }) {
                         address: a.road ? `${a.house_number ? a.house_number + ' ' : ''}${a.road}` : '',
                     }));
                 })
-                .catch(() => {});
+                .catch(err => { if (err.name !== 'AbortError') console.error(err); });
         },
     });
     return position ? <Marker position={position} /> : null;

--- a/frontend/src/components/AdminAddCourse.jsx
+++ b/frontend/src/components/AdminAddCourse.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Form, Button, Row, Col, Alert, Spinner } from 'react-bootstrap';
+import api from '../services/api';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+const EMPTY_FORM = { club_name: '', course_name: '', address: '', city: '', state: '', country: '' };
+
+function LocationPicker({ position, setPosition, setForm }) {
+    useMapEvents({
+        click(e) {
+            const { lat, lng } = e.latlng;
+            setPosition([lat, lng]);
+            fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`)
+                .then(r => r.json())
+                .then(data => {
+                    const a = data.address || {};
+                    setForm(prev => ({
+                        ...prev,
+                        city: a.city || a.town || a.village || a.hamlet || '',
+                        state: a.state || '',
+                        country: a.country || '',
+                        address: a.road ? `${a.house_number ? a.house_number + ' ' : ''}${a.road}` : '',
+                    }));
+                })
+                .catch(() => {});
+        },
+    });
+    return position ? <Marker position={position} /> : null;
+}
+
+export default function AdminAddCourse() {
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [position, setPosition] = useState(null);
+    const [alert, setAlert] = useState(null);
+    const [saving, setSaving] = useState(false);
+
+    const handleField = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+
+    const handleSubmit = async e => {
+        e.preventDefault();
+        if (!position) { setAlert({ variant: 'warning', msg: 'Click the map to set a location first.' }); return; }
+        setSaving(true);
+        setAlert(null);
+        try {
+            const res = await api.post('/admin/courses', {
+                ...form,
+                latitude: position[0],
+                longitude: position[1],
+            });
+            setAlert({ variant: 'success', msg: `Course "${res.data.display_name}" (ID ${res.data.id}) added successfully.` });
+            setForm(EMPTY_FORM);
+            setPosition(null);
+        } catch (err) {
+            setAlert({ variant: 'danger', msg: err.response?.data?.detail || 'Failed to add course.' });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="p-3">
+            <h4 className="mb-3">Add Course</h4>
+            {alert && <Alert variant={alert.variant} dismissible onClose={() => setAlert(null)}>{alert.msg}</Alert>}
+            <Row>
+                <Col md={5}>
+                    <Form onSubmit={handleSubmit}>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Club Name</Form.Label>
+                            <Form.Control name="club_name" value={form.club_name} onChange={handleField} placeholder="e.g. Augusta National" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Course Name</Form.Label>
+                            <Form.Control name="course_name" value={form.course_name} onChange={handleField} placeholder="e.g. Championship Course" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Address</Form.Label>
+                            <Form.Control name="address" value={form.address} onChange={handleField} placeholder="Street address" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>City</Form.Label>
+                            <Form.Control name="city" value={form.city} onChange={handleField} />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>State / Province</Form.Label>
+                            <Form.Control name="state" value={form.state} onChange={handleField} />
+                        </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Country</Form.Label>
+                            <Form.Control name="country" value={form.country} onChange={handleField} />
+                        </Form.Group>
+                        <div className="mb-3 text-muted" style={{ fontSize: '0.9rem' }}>
+                            {position
+                                ? <><strong>Lat:</strong> {position[0].toFixed(6)} &nbsp; <strong>Lng:</strong> {position[1].toFixed(6)}</>
+                                : 'Click the map to set coordinates'}
+                        </div>
+                        <Button type="submit" variant="primary" disabled={saving || !position}>
+                            {saving ? <><Spinner size="sm" className="me-1" />Saving…</> : 'Add Course'}
+                        </Button>
+                    </Form>
+                </Col>
+                <Col md={7}>
+                    <p className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>Click anywhere on the map to set the course location. Address fields will auto-fill.</p>
+                    <MapContainer center={[39, -98]} zoom={4} style={{ height: '480px', width: '100%', borderRadius: '6px' }}>
+                        <TileLayer
+                            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                        />
+                        <LocationPicker position={position} setPosition={setPosition} setForm={setForm} />
+                    </MapContainer>
+                </Col>
+            </Row>
+        </div>
+    );
+}

--- a/frontend/src/components/AdminAddCourse.jsx
+++ b/frontend/src/components/AdminAddCourse.jsx
@@ -4,6 +4,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { Form, Button, Row, Col, Alert, Spinner } from 'react-bootstrap';
 import api from '../services/api';
+import { nominatimToGeoFields } from '../utils/geoLookup';
 
 import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
 import markerIcon from 'leaflet/dist/images/marker-icon.png';
@@ -27,11 +28,12 @@ function LocationPicker({ position, setPosition, setForm }) {
                 .then(r => r.json())
                 .then(data => {
                     const a = data.address || {};
+                    const { city, state, country } = nominatimToGeoFields(a);
                     setForm(prev => ({
                         ...prev,
-                        city: a.city || a.town || a.village || a.hamlet || '',
-                        state: a.state || '',
-                        country: a.country || '',
+                        city,
+                        state,
+                        country,
                         address: a.road ? `${a.house_number ? a.house_number + ' ' : ''}${a.road}` : '',
                     }));
                 })

--- a/frontend/src/components/AdminEditCourse.jsx
+++ b/frontend/src/components/AdminEditCourse.jsx
@@ -1,0 +1,158 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Form, Button, Row, Col, Alert, Spinner, Card } from 'react-bootstrap';
+import api from '../services/api';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+function FlyTo({ target }) {
+    const map = useMap();
+    useEffect(() => {
+        if (target) map.flyTo(target, 14);
+    }, [target, map]);
+    return null;
+}
+
+function DraggableMarker({ position, setPosition }) {
+    const markerRef = useRef(null);
+    const eventHandlers = {
+        dragend() {
+            const m = markerRef.current;
+            if (m) setPosition(m.getLatLng());
+        },
+    };
+    return <Marker draggable position={position} eventHandlers={eventHandlers} ref={markerRef} />;
+}
+
+function MapClickHandler({ setPosition }) {
+    useMapEvents({ click(e) { setPosition(e.latlng); } });
+    return null;
+}
+
+export default function AdminEditCourse() {
+    const [courseId, setCourseId] = useState('');
+    const [course, setCourse] = useState(null);
+    const [position, setPosition] = useState(null);
+    const [flyTarget, setFlyTarget] = useState(null);
+    const [loadAlert, setLoadAlert] = useState(null);
+    const [saveAlert, setSaveAlert] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+
+    const handleLoad = async e => {
+        e.preventDefault();
+        if (!courseId) return;
+        setLoading(true);
+        setLoadAlert(null);
+        setCourse(null);
+        setSaveAlert(null);
+        try {
+            const res = await api.get(`/garmin_courses/course/${courseId}`);
+            const c = res.data;
+            setCourse(c);
+            const pos = { lat: c.latitude, lng: c.longitude };
+            setPosition(pos);
+            setFlyTarget(pos);
+        } catch (err) {
+            setLoadAlert(err.response?.status === 404 ? `Course ID ${courseId} not found.` : 'Failed to load course.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSave = async e => {
+        e.preventDefault();
+        if (!course || !position) return;
+        setSaving(true);
+        setSaveAlert(null);
+        try {
+            await api.put(`/admin/courses/${course.id}/location`, {
+                latitude: position.lat ?? position[0],
+                longitude: position.lng ?? position[1],
+            });
+            setSaveAlert({ variant: 'success', msg: 'Location updated successfully.' });
+        } catch (err) {
+            setSaveAlert({ variant: 'danger', msg: err.response?.data?.detail || 'Failed to update location.' });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const lat = position ? (position.lat ?? position[0]) : null;
+    const lng = position ? (position.lng ?? position[1]) : null;
+
+    return (
+        <div className="p-3">
+            <h4 className="mb-3">Edit Course Location</h4>
+
+            <Form onSubmit={handleLoad} className="mb-3">
+                <Row className="align-items-end g-2">
+                    <Col xs="auto">
+                        <Form.Label>Course ID</Form.Label>
+                        <Form.Control
+                            type="number"
+                            min="1"
+                            value={courseId}
+                            onChange={e => setCourseId(e.target.value)}
+                            placeholder="Enter course ID"
+                            style={{ width: '160px' }}
+                        />
+                    </Col>
+                    <Col xs="auto">
+                        <Button type="submit" variant="secondary" disabled={loading || !courseId}>
+                            {loading ? <><Spinner size="sm" className="me-1" />Loading…</> : 'Load Course'}
+                        </Button>
+                    </Col>
+                </Row>
+                {loadAlert && <Alert variant="warning" className="mt-2 mb-0">{loadAlert}</Alert>}
+            </Form>
+
+            {course && (
+                <>
+                    <Card className="mb-3">
+                        <Card.Body className="py-2">
+                            <strong>{course.display_name}</strong>
+                            <span className="text-muted ms-2">{[course.city, course.state, course.country].filter(Boolean).join(', ')}</span>
+                        </Card.Body>
+                    </Card>
+
+                    {saveAlert && <Alert variant={saveAlert.variant} dismissible onClose={() => setSaveAlert(null)}>{saveAlert.msg}</Alert>}
+
+                    <p className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>
+                        Drag the marker or click anywhere on the map to set the new location.
+                    </p>
+                    <Row>
+                        <Col md={9}>
+                            <MapContainer center={[lat, lng]} zoom={14} style={{ height: '460px', width: '100%', borderRadius: '6px' }}>
+                                <TileLayer
+                                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                />
+                                <FlyTo target={flyTarget} />
+                                <MapClickHandler setPosition={setPosition} />
+                                {position && <DraggableMarker position={position} setPosition={setPosition} />}
+                            </MapContainer>
+                        </Col>
+                        <Col md={3} className="d-flex flex-column justify-content-center">
+                            <div className="mb-3">
+                                <div className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>New coordinates</div>
+                                <div><strong>Lat:</strong> {lat?.toFixed(6)}</div>
+                                <div><strong>Lng:</strong> {lng?.toFixed(6)}</div>
+                            </div>
+                            <Button variant="primary" onClick={handleSave} disabled={saving}>
+                                {saving ? <><Spinner size="sm" className="me-1" />Saving…</> : 'Save Location'}
+                            </Button>
+                        </Col>
+                    </Row>
+                </>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/AdminEditCourse.jsx
+++ b/frontend/src/components/AdminEditCourse.jsx
@@ -12,6 +12,8 @@ import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
 
+const DEFAULT_CENTER = [39, -98];
+
 function FlyTo({ target }) {
     const map = useMap();
     useEffect(() => {
@@ -57,7 +59,9 @@ export default function AdminEditCourse() {
             const res = await api.get(`/garmin_courses/course/${courseId}`);
             const c = res.data;
             setCourse(c);
-            const pos = { lat: c.latitude, lng: c.longitude };
+            const pos = Number.isFinite(c.latitude) && Number.isFinite(c.longitude)
+                ? { lat: c.latitude, lng: c.longitude }
+                : null;
             setPosition(pos);
             setFlyTarget(pos);
         } catch (err) {
@@ -130,7 +134,7 @@ export default function AdminEditCourse() {
                     </p>
                     <Row>
                         <Col md={9}>
-                            <MapContainer center={[lat, lng]} zoom={14} style={{ height: '460px', width: '100%', borderRadius: '6px' }}>
+                            <MapContainer center={position ? [lat, lng] : DEFAULT_CENTER} zoom={position ? 14 : 4} style={{ height: '460px', width: '100%', borderRadius: '6px' }}>
                                 <TileLayer
                                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -146,7 +150,7 @@ export default function AdminEditCourse() {
                                 <div><strong>Lat:</strong> {lat?.toFixed(6)}</div>
                                 <div><strong>Lng:</strong> {lng?.toFixed(6)}</div>
                             </div>
-                            <Button variant="primary" onClick={handleSave} disabled={saving}>
+                            <Button variant="primary" onClick={handleSave} disabled={saving || !position}>
                                 {saving ? <><Spinner size="sm" className="me-1" />Saving…</> : 'Save Location'}
                             </Button>
                         </Col>

--- a/frontend/src/components/AdminNav.jsx
+++ b/frontend/src/components/AdminNav.jsx
@@ -9,6 +9,12 @@ const AdminNav = () => (
         <NavLink to="/admin/users" className={adminNavLinkClass}>
             User Management
         </NavLink>
+        <NavLink to="/admin/add-course" className={adminNavLinkClass}>
+            Add Course
+        </NavLink>
+        <NavLink to="/admin/edit-course" className={adminNavLinkClass}>
+            Edit Course Location
+        </NavLink>
     </nav>
 );
 

--- a/frontend/src/components/CourseCard.jsx
+++ b/frontend/src/components/CourseCard.jsx
@@ -36,7 +36,12 @@ function CourseCard({ id, display_name, city, year, onDelete, onYearSave }) {
         <tr>
             <td className="td-course-name">{display_name}</td>
             <td className="td-location">{city}</td>
-            <td className="td-year">
+            <td
+                className="td-year"
+                onClick={editing ? undefined : startEdit}
+                title={editing ? undefined : 'Click to edit year'}
+                style={editing ? undefined : { cursor: 'pointer' }}
+            >
                 {editing ? (
                     <input
                         ref={inputRef}
@@ -50,11 +55,7 @@ function CourseCard({ id, display_name, city, year, onDelete, onYearSave }) {
                         max="2070"
                     />
                 ) : (
-                    <span
-                        onClick={startEdit}
-                        title="Click to edit year"
-                        style={{ cursor: 'pointer', borderBottom: '1px dashed var(--text-muted)', paddingBottom: '1px' }}
-                    >
+                    <span style={{ borderBottom: '1px dashed var(--text-muted)', paddingBottom: '1px' }}>
                         {year ?? '—'}
                     </span>
                 )}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -10,6 +10,8 @@ import NewUser from './components/NewUser';
 import GarminCourses from './components/GarminCourses';
 import CourseSearch from './components/CourseSearch';
 import AdminUsers from './components/AdminUsers';
+import AdminAddCourse from './components/AdminAddCourse';
+import AdminEditCourse from './components/AdminEditCourse';
 
 const router = createBrowserRouter([
     {
@@ -33,6 +35,8 @@ const router = createBrowserRouter([
         element: <AdminRoute />,
         children: [
             { path: '/admin/users', element: <AdminUsers /> },
+            { path: '/admin/add-course', element: <AdminAddCourse /> },
+            { path: '/admin/edit-course', element: <AdminEditCourse /> },
         ],
     },
     {

--- a/frontend/src/utils/geoLookup.js
+++ b/frontend/src/utils/geoLookup.js
@@ -1,0 +1,125 @@
+// Maps Nominatim's address.country_code (ISO 3166-1 alpha-2, lowercase) to ISO 3166-1 alpha-3
+const ALPHA2_TO_ALPHA3 = {
+      'af': 'AFG', 'ax': 'ALA', 'al': 'ALB', 'dz': 'DZA',
+      'as': 'ASM', 'ad': 'AND', 'ao': 'AGO', 'ai': 'AIA',
+      'aq': 'ATA', 'ag': 'ATG', 'ar': 'ARG', 'am': 'ARM',
+      'aw': 'ABW', 'au': 'AUS', 'at': 'AUT', 'az': 'AZE',
+      'bs': 'BHS', 'bh': 'BHR', 'bd': 'BGD', 'bb': 'BRB',
+      'by': 'BLR', 'be': 'BEL', 'bz': 'BLZ', 'bj': 'BEN',
+      'bm': 'BMU', 'bt': 'BTN', 'bo': 'BOL', 'bq': 'BES',
+      'ba': 'BIH', 'bw': 'BWA', 'bv': 'BVT', 'br': 'BRA',
+      'io': 'IOT', 'bn': 'BRN', 'bg': 'BGR', 'bf': 'BFA',
+      'bi': 'BDI', 'cv': 'CPV', 'kh': 'KHM', 'cm': 'CMR',
+      'ca': 'CAN', 'ky': 'CYM', 'cf': 'CAF', 'td': 'TCD',
+      'cl': 'CHL', 'cn': 'CHN', 'cx': 'CXR', 'cc': 'CCK',
+      'co': 'COL', 'km': 'COM', 'cg': 'COG', 'cd': 'COD',
+      'ck': 'COK', 'cr': 'CRI', 'ci': 'CIV', 'hr': 'HRV',
+      'cu': 'CUB', 'cw': 'CUW', 'cy': 'CYP', 'cz': 'CZE',
+      'dk': 'DNK', 'dj': 'DJI', 'dm': 'DMA', 'do': 'DOM',
+      'ec': 'ECU', 'eg': 'EGY', 'sv': 'SLV', 'gq': 'GNQ',
+      'er': 'ERI', 'ee': 'EST', 'sz': 'SWZ', 'et': 'ETH',
+      'fk': 'FLK', 'fo': 'FRO', 'fj': 'FJI', 'fi': 'FIN',
+      'fr': 'FRA', 'gf': 'GUF', 'pf': 'PYF', 'tf': 'ATF',
+      'ga': 'GAB', 'gm': 'GMB', 'ge': 'GEO', 'de': 'DEU',
+      'gh': 'GHA', 'gi': 'GIB', 'gr': 'GRC', 'gl': 'GRL',
+      'gd': 'GRD', 'gp': 'GLP', 'gu': 'GUM', 'gt': 'GTM',
+      'gg': 'GGY', 'gn': 'GIN', 'gw': 'GNB', 'gy': 'GUY',
+      'ht': 'HTI', 'hm': 'HMD', 'va': 'VAT', 'hn': 'HND',
+      'hk': 'HKG', 'hu': 'HUN', 'is': 'ISL', 'in': 'IND',
+      'id': 'IDN', 'ir': 'IRN', 'iq': 'IRQ', 'ie': 'IRL',
+      'im': 'IMN', 'il': 'ISR', 'it': 'ITA', 'jm': 'JAM',
+      'jp': 'JPN', 'je': 'JEY', 'jo': 'JOR', 'kz': 'KAZ',
+      'ke': 'KEN', 'ki': 'KIR', 'kp': 'PRK', 'kr': 'KOR',
+      'kw': 'KWT', 'kg': 'KGZ', 'la': 'LAO', 'lv': 'LVA',
+      'lb': 'LBN', 'ls': 'LSO', 'lr': 'LBR', 'ly': 'LBY',
+      'li': 'LIE', 'lt': 'LTU', 'lu': 'LUX', 'mo': 'MAC',
+      'mg': 'MDG', 'mw': 'MWI', 'my': 'MYS', 'mv': 'MDV',
+      'ml': 'MLI', 'mt': 'MLT', 'mh': 'MHL', 'mq': 'MTQ',
+      'mr': 'MRT', 'mu': 'MUS', 'yt': 'MYT', 'mx': 'MEX',
+      'fm': 'FSM', 'md': 'MDA', 'mc': 'MCO', 'mn': 'MNG',
+      'me': 'MNE', 'ms': 'MSR', 'ma': 'MAR', 'mz': 'MOZ',
+      'mm': 'MMR', 'na': 'NAM', 'nr': 'NRU', 'np': 'NPL',
+      'nl': 'NLD', 'nc': 'NCL', 'nz': 'NZL', 'ni': 'NIC',
+      'ne': 'NER', 'ng': 'NGA', 'nu': 'NIU', 'nf': 'NFK',
+      'mk': 'MKD', 'mp': 'MNP', 'no': 'NOR', 'om': 'OMN',
+      'pk': 'PAK', 'pw': 'PLW', 'ps': 'PSE', 'pa': 'PAN',
+      'pg': 'PNG', 'py': 'PRY', 'pe': 'PER', 'ph': 'PHL',
+      'pn': 'PCN', 'pl': 'POL', 'pt': 'PRT', 'pr': 'PRI',
+      'qa': 'QAT', 're': 'REU', 'ro': 'ROU', 'ru': 'RUS',
+      'rw': 'RWA', 'bl': 'BLM', 'sh': 'SHN', 'kn': 'KNA',
+      'lc': 'LCA', 'mf': 'MAF', 'pm': 'SPM', 'vc': 'VCT',
+      'ws': 'WSM', 'sm': 'SMR', 'st': 'STP', 'sa': 'SAU',
+      'sn': 'SEN', 'rs': 'SRB', 'sc': 'SYC', 'sl': 'SLE',
+      'sg': 'SGP', 'sx': 'SXM', 'sk': 'SVK', 'si': 'SVN',
+      'sb': 'SLB', 'so': 'SOM', 'za': 'ZAF', 'gs': 'SGS',
+      'ss': 'SSD', 'es': 'ESP', 'lk': 'LKA', 'sd': 'SDN',
+      'sr': 'SUR', 'sj': 'SJM', 'se': 'SWE', 'ch': 'CHE',
+      'sy': 'SYR', 'tw': 'TWN', 'tj': 'TJK', 'tz': 'TZA',
+      'th': 'THA', 'tl': 'TLS', 'tg': 'TGO', 'tk': 'TKL',
+      'to': 'TON', 'tt': 'TTO', 'tn': 'TUN', 'tr': 'TUR',
+      'tm': 'TKM', 'tc': 'TCA', 'tv': 'TUV', 'ug': 'UGA',
+      'ua': 'UKR', 'ae': 'ARE', 'gb': 'GBR', 'us': 'USA',
+      'um': 'UMI', 'uy': 'URY', 'uz': 'UZB', 'vu': 'VUT',
+      've': 'VEN', 'vn': 'VNM', 'vg': 'VGB', 'vi': 'VIR',
+      'wf': 'WLF', 'eh': 'ESH', 'ye': 'YEM', 'zm': 'ZMB',
+      'zw': 'ZWE',
+};
+
+// Maps full state/province names to abbreviations, keyed by alpha-2 country code
+const STATE_ABBR = {
+    us: {
+        'Alabama': 'AL', 'Alaska': 'AK', 'Arizona': 'AZ', 'Arkansas': 'AR',
+        'California': 'CA', 'Colorado': 'CO', 'Connecticut': 'CT', 'Delaware': 'DE',
+        'Florida': 'FL', 'Georgia': 'GA', 'Hawaii': 'HI', 'Idaho': 'ID',
+        'Illinois': 'IL', 'Indiana': 'IN', 'Iowa': 'IA', 'Kansas': 'KS',
+        'Kentucky': 'KY', 'Louisiana': 'LA', 'Maine': 'ME', 'Maryland': 'MD',
+        'Massachusetts': 'MA', 'Michigan': 'MI', 'Minnesota': 'MN', 'Mississippi': 'MS',
+        'Missouri': 'MO', 'Montana': 'MT', 'Nebraska': 'NE', 'Nevada': 'NV',
+        'New Hampshire': 'NH', 'New Jersey': 'NJ', 'New Mexico': 'NM', 'New York': 'NY',
+        'North Carolina': 'NC', 'North Dakota': 'ND', 'Ohio': 'OH', 'Oklahoma': 'OK',
+        'Oregon': 'OR', 'Pennsylvania': 'PA', 'Rhode Island': 'RI', 'South Carolina': 'SC',
+        'South Dakota': 'SD', 'Tennessee': 'TN', 'Texas': 'TX', 'Utah': 'UT',
+        'Vermont': 'VT', 'Virginia': 'VA', 'Washington': 'WA', 'West Virginia': 'WV',
+        'Wisconsin': 'WI', 'Wyoming': 'WY', 'District of Columbia': 'DC',
+    },
+    ca: {
+        'Alberta': 'AB', 'British Columbia': 'BC', 'Manitoba': 'MB',
+        'New Brunswick': 'NB', 'Newfoundland and Labrador': 'NL', 'Nova Scotia': 'NS',
+        'Ontario': 'ON', 'Prince Edward Island': 'PE', 'Quebec': 'QC',
+        'Saskatchewan': 'SK', 'Northwest Territories': 'NT', 'Nunavut': 'NU', 'Yukon': 'YT',
+    },
+    au: {
+        'New South Wales': 'NSW', 'Victoria': 'VIC', 'Queensland': 'QLD',
+        'Western Australia': 'WA', 'South Australia': 'SA', 'Tasmania': 'TAS',
+        'Australian Capital Territory': 'ACT', 'Northern Territory': 'NT',
+    },
+    mx: {
+        'Aguascalientes': 'AGS', 'Baja California': 'BC', 'Baja California Sur': 'BCS',
+        'Campeche': 'CAMP', 'Chiapas': 'CHIS', 'Chihuahua': 'CHIH',
+        'Coahuila': 'COAH', 'Colima': 'COL', 'Durango': 'DGO',
+        'Guanajuato': 'GTO', 'Guerrero': 'GRO', 'Hidalgo': 'HGO',
+        'Jalisco': 'JAL', 'Mexico City': 'CDMX', 'México': 'MEX',
+        'Michoacán': 'MICH', 'Morelos': 'MOR', 'Nayarit': 'NAY',
+        'Nuevo León': 'NL', 'Oaxaca': 'OAX', 'Puebla': 'PUE',
+        'Querétaro': 'QRO', 'Quintana Roo': 'QR', 'San Luis Potosí': 'SLP',
+        'Sinaloa': 'SIN', 'Sonora': 'SON', 'Tabasco': 'TAB',
+        'Tamaulipas': 'TAMPS', 'Tlaxcala': 'TLAX', 'Veracruz': 'VER',
+        'Yucatán': 'YUC', 'Zacatecas': 'ZAC',
+    },
+    // ... add more countries as needed
+};
+
+/**
+ * Convert a Nominatim address object to { city, state, country } using standard codes.
+ * @param {object} a - address field from Nominatim reverse geocode response
+ * @returns {{ city: string, state: string, country: string }}
+ */
+export function nominatimToGeoFields(a) {
+    const cc = (a.country_code || '').toLowerCase();
+    const fullState = a.state || '';
+    const stateMap = STATE_ABBR[cc];
+    const state = stateMap ? (stateMap[fullState] || fullState) : fullState;
+    const country = ALPHA2_TO_ALPHA3[cc] || a.country || '';
+    const city = a.city || a.town || a.village || a.hamlet || '';
+    return { city, state, country };
+}


### PR DESCRIPTION
## Summary

- Adds two new admin pages — **Add Course** and **Edit Course Location** — with interactive Leaflet maps
- Clicking the map on the Add Course page drops a pin and auto-fills address fields via Nominatim reverse geocoding
- Edit Course loads an existing course by ID, then lets the admin drag the marker or click to reposition it before saving
- Backs both pages with new admin-only API endpoints: `POST /admin/courses` and `PUT /admin/courses/{id}/location`
- Adds `leaflet` and `react-leaflet` to frontend dependencies

## Test plan

- [ ] Log in as admin and navigate to **Add Course** — verify map renders, clicking drops a marker and auto-fills city/state/country, form submits and returns the new course
- [ ] Navigate to **Edit Course Location** — load a course by ID, drag or click to reposition, save and confirm coordinates updated in the DB
- [ ] Verify both routes are protected (non-admin users receive 401)
- [ ] Confirm non-admin users do not see the new nav links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can create courses via a map-driven form with automatic address lookup after selecting coordinates
  * Admins can load a course and update its location using an interactive map (click or drag marker)
  * Admin navigation includes direct links to add and edit course location pages
* **Chores**
  * Frontend mapping support added to enable the new map experiences

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeorgeBronner/golfmapper3/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->