### PR TITLE
Add email-based password reset

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -7,7 +7,6 @@ __pycache__/
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
-.idea
 .DS_Store
 *.suo
 *.ntvs*

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -12,6 +13,10 @@ class Settings(BaseSettings):
     DB_PORT: str = "5432"
     SENTRY_DSN: str = ""
     STATIC_FILES_DIR: str = "./dist"
+    MAILTRAP_API_KEY: str = ""
+    APP_BASE_URL: str = "https://golf.bronnerapp.com"
+    FROM_EMAIL: str = "noreply@bronnerapp.com"
+    FROM_NAME: str = "GolfMapper"
     MAP_FILES_DIR: str = "./static/user_maps"
     TRACES_SAMPLE_RATE: float = 0.1
     TOKEN_EXPIRE_MINUTES: int = 90

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from app.config import settings
-
 
 if settings.USE_SQLITE_DB:
     if settings.SQLITE_DB_URL:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,9 +1,11 @@
 import ssl
+from typing import Annotated
+
 import certifi
 import geopy.geocoders
-from typing import Annotated
-from sqlalchemy.orm import Session
 from fastapi import Depends
+from sqlalchemy.orm import Session
+
 from app.database import SessionLocal
 from app.routers.auth import get_current_user
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,18 +4,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-from starlette.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from fastapi_pagination import add_pagination
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from starlette.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.database import engine
 from app.limiter import limiter
-from app.routers import garmin_courses, auth, admin, users, user_courses, map
 from app.models import Base
+from app.routers import admin, auth, garmin_courses, map, password_reset, user_courses, users
 
 try:
     import sentry_sdk
@@ -94,6 +94,7 @@ app.include_router(admin.router, prefix=API_PREFIX)
 app.include_router(users.router, prefix=API_PREFIX)
 app.include_router(user_courses.router, prefix=API_PREFIX)
 app.include_router(map.router, prefix=API_PREFIX)
+app.include_router(password_reset.router, prefix=API_PREFIX)
 
 # --- Static assets ---
 if assets_path.exists() and assets_path.is_dir():

--- a/backend/app/manual_GPS_edit.py
+++ b/backend/app/manual_GPS_edit.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
-from sqlalchemy import create_engine
-from sqlalchemy import Column, Integer, String, Float
-from sqlalchemy.orm import declarative_base, sessionmaker
+
 from dotenv import load_dotenv
+from sqlalchemy import Column, Float, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 load_dotenv(dotenv_path=Path(__file__).parent / '.env')
 
@@ -46,7 +46,7 @@ class courses(Base):
 Session_sqlite = sessionmaker(bind=engine_sqlite)
 session_sqlite = Session_sqlite()
 
-result = int(input(f"Which course id to you want to edit? "))
+result = int(input("Which course id to you want to edit? "))
 i = session_sqlite.get(courses, result)
 # j = session.get(courses, result)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,10 +1,23 @@
 from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
 
 from app.database import Base
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Float, DateTime, UniqueConstraint
 
-_now = lambda: datetime.now(timezone.utc)
+
+def _now():
+    return datetime.now(timezone.utc)
 
 
 class Courses(Base):
@@ -76,4 +89,19 @@ class UserCourses(Base):
 
     __table_args__ = (
         UniqueConstraint('user_id', 'course_id', 'year', name='uq_user_course_year'),
+    )
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    token_hash = Column(String, nullable=False, unique=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=_now)
+
+    __table_args__ = (
+        Index("ix_prt_token_hash", "token_hash"),
     )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,10 +1,12 @@
-import bcrypt
 from datetime import datetime, timezone
+
+import bcrypt
 from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel, ConfigDict, Field
 from starlette import status
-from app.models import Courses, Users
+
 from app.dependencies import db_dependency, user_dependency
+from app.models import Courses, Users
 from app.routers.garmin_courses import CourseBase
 
 router = APIRouter(prefix="/admin", tags=["admin"])

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,17 +1,19 @@
 import logging
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
+
+import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-import bcrypt
 from starlette import status
-from app.models import Users
-from app.database import SessionLocal
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from jose import jwt, JWTError
+
 from app.config import settings
+from app.database import SessionLocal
 from app.limiter import limiter
+from app.models import Users
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_bearer)]):
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
         return {"username": username, "id": user_id, "role": user_role}
     except JWTError:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials") from None
 
 
 class CreateUserRequest(BaseModel):

--- a/backend/app/routers/garmin_courses.py
+++ b/backend/app/routers/garmin_courses.py
@@ -1,15 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from starlette import status
-from sqlalchemy import select, func
-from sqlalchemy.orm import Session
 from typing import Optional
-from app.models import Courses
-from app.dependencies import db_dependency, user_dependency, get_db
-from geopy.distance import geodesic
+
 import geopy.geocoders
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
+from geopy.distance import geodesic
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+from starlette import status
+
+from app.dependencies import db_dependency, get_db, user_dependency
+from app.models import Courses
 
 router = APIRouter(prefix="/garmin_courses", tags=["garmin_courses"])
 
@@ -91,7 +93,7 @@ async def get_city_coordinates(city: str = Query(...), state: str = None, countr
     except HTTPException:
         raise
     except Exception:
-        raise HTTPException(status_code=500, detail="Geocoding service error")
+        raise HTTPException(status_code=500, detail="Geocoding service error") from None
 
 
 def courses_from_location(
@@ -122,7 +124,7 @@ async def get_zipcode_coordinates(zipcode: str = Query(...), country: Optional[s
     except HTTPException:
         raise
     except Exception:
-        raise HTTPException(status_code=500, detail="Geocoding service error")
+        raise HTTPException(status_code=500, detail="Geocoding service error") from None
 
 
 @router.get("/zipcode_closest_courses/")
@@ -141,7 +143,7 @@ async def zipcode_closest_courses(
     except HTTPException:
         raise
     except Exception:
-        raise HTTPException(status_code=500, detail="Geocoding service error")
+        raise HTTPException(status_code=500, detail="Geocoding service error") from None
 
 
 @router.get("/city_closest_courses/")
@@ -166,4 +168,4 @@ async def city_closest_courses(
     except HTTPException:
         raise
     except Exception:
-        raise HTTPException(status_code=500, detail="Geocoding service error")
+        raise HTTPException(status_code=500, detail="Geocoding service error") from None

--- a/backend/app/routers/map.py
+++ b/backend/app/routers/map.py
@@ -1,13 +1,14 @@
 from pathlib import Path
-from fastapi import APIRouter, HTTPException
-from starlette import status
-from fastapi.responses import FileResponse, HTMLResponse
+
 import folium
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse, HTMLResponse
+from starlette import status
 
 from app.config import settings
-from app.routers.user_courses import readall
 from app.dependencies import db_dependency, user_dependency
-from app.models import Users, Courses, UserCourses
+from app.models import Courses, UserCourses, Users
+from app.routers.user_courses import readall
 
 MAP_DIR = Path(settings.MAP_FILES_DIR)
 

--- a/backend/app/routers/password_reset.py
+++ b/backend/app/routers/password_reset.py
@@ -1,0 +1,160 @@
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+import bcrypt
+import mailtrap as mt
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from starlette import status
+
+from app.config import settings
+from app.database import SessionLocal
+from app.limiter import limiter
+from app.models import PasswordResetToken, Users
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+TOKEN_EXPIRY_MINUTES = 15
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _send_reset_email(to_email: str, to_name: str, reset_url: str) -> None:
+    if not settings.MAILTRAP_API_KEY:
+        logger.warning("MAILTRAP_API_KEY not set — skipping email send for %s", to_email)
+        return
+
+    client = mt.MailtrapClient(token=settings.MAILTRAP_API_KEY)
+    mail = mt.Mail(
+        sender=mt.Address(email=settings.FROM_EMAIL, name=settings.FROM_NAME),
+        to=[mt.Address(email=to_email, name=to_name)],
+        subject="Reset your GolfMapper password",
+        text=(
+            f"Hi {to_name},\n\n"
+            "We received a request to reset your GolfMapper password.\n\n"
+            f"Click the link below to set a new password (valid for {TOKEN_EXPIRY_MINUTES} minutes):\n\n"
+            f"{reset_url}\n\n"
+            "If you didn't request this, you can safely ignore this email.\n\n"
+            "— The GolfMapper Team"
+        ),
+        html=(
+            f"<p>Hi {to_name},</p>"
+            "<p>We received a request to reset your GolfMapper password.</p>"
+            f"<p><a href=\"{reset_url}\">Reset my password</a></p>"
+            f"<p>This link is valid for {TOKEN_EXPIRY_MINUTES} minutes. "
+            "If you didn't request this, ignore this email.</p>"
+            "<p>— The GolfMapper Team</p>"
+        ),
+        category="Password Reset",
+    )
+    client.send(mail)
+    logger.info("Password reset email sent to %s", to_email)
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: str
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str
+
+
+@router.post("/forgot-password", status_code=status.HTTP_200_OK)
+@limiter.limit("5/minute")
+async def forgot_password(
+    request: Request,
+    body: ForgotPasswordRequest,
+    db: db_dependency,
+):
+    # Always return success to avoid user enumeration
+    user = db.query(Users).filter(Users.email == body.email).first()
+    if user:
+        # Invalidate any existing unused tokens for this user
+        db.query(PasswordResetToken).filter(
+            PasswordResetToken.user_id == user.id,
+            PasswordResetToken.used == False,  # noqa: E712
+        ).delete()
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_token(raw_token)
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=TOKEN_EXPIRY_MINUTES)
+
+        db.add(PasswordResetToken(user_id=user.id, token_hash=token_hash, expires_at=expires_at))
+
+        reset_url = f"{settings.APP_BASE_URL}/reset-password?token={raw_token}"
+        try:
+            _send_reset_email(
+                to_email=user.email,
+                to_name=user.first_name or user.username,
+                reset_url=reset_url,
+            )
+            db.commit()
+            logger.info("Password reset requested for user_id=%s", user.id)
+        except (mt.AuthorizationError, mt.APIError) as e:
+            logger.error("Password reset email failed for user_id=%s: %s", user.id, e)
+            db.rollback()
+
+    return {"message": "If that email is registered, a reset link has been sent."}
+
+
+@router.post("/reset-password", status_code=status.HTTP_200_OK)
+@limiter.limit("10/minute")
+async def reset_password(request: Request, body: ResetPasswordRequest, db: db_dependency):
+    token_hash = _hash_token(body.token)
+    now = datetime.now(timezone.utc)
+
+    reset_token = (
+        db.query(PasswordResetToken)
+        .filter(
+            PasswordResetToken.token_hash == token_hash,
+            PasswordResetToken.used == False,  # noqa: E712
+            PasswordResetToken.expires_at > now,
+        )
+        .first()
+    )
+
+    if not reset_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset link.",
+        )
+
+    if len(body.new_password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Password must be at least 8 characters.",
+        )
+
+    user = db.query(Users).filter(Users.id == reset_token.user_id).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired reset link.",
+        )
+
+    user.hashed_password = bcrypt.hashpw(body.new_password.encode(), bcrypt.gensalt()).decode()
+    reset_token.used = True
+    db.commit()
+
+    logger.info("Password reset completed for user_id=%s", user.id)
+    return {"message": "Password updated successfully."}

--- a/backend/app/routers/user_courses.py
+++ b/backend/app/routers/user_courses.py
@@ -1,11 +1,13 @@
 from datetime import datetime
 from pathlib import Path as FilePath
+
 from fastapi import APIRouter, HTTPException, Path
-from starlette import status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from starlette import status
+
 from app.config import settings
-from app.models import Courses, UserCourses
 from app.dependencies import db_dependency, user_dependency
+from app.models import Courses, UserCourses
 
 _MAP_DIR = FilePath(settings.MAP_FILES_DIR)
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+
+import bcrypt
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
-from app.models import Users
+
 from app.dependencies import db_dependency, user_dependency
-import bcrypt
+from app.models import Users
 
 router = APIRouter(prefix="/user", tags=["user"])
 

--- a/backend/app/utils/map_course_entry.py
+++ b/backend/app/utils/map_course_entry.py
@@ -4,16 +4,17 @@ Allows adding new courses to the database by clicking on a map
 Uses OpenStreetMaps with Leaflet and reverse geocoding
 """
 
+import sys
+from datetime import datetime
+from typing import Optional
+
+import httpx
+import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
-from sqlalchemy import create_engine, Column, Integer, String, Float
-from sqlalchemy.orm import sessionmaker, declarative_base
 from pydantic import BaseModel
-from typing import Optional
-from datetime import datetime
-import uvicorn
-import sys
-import httpx
+from sqlalchemy import Column, Float, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Fix encoding for Windows console
 if sys.platform == "win32":
@@ -204,7 +205,7 @@ async def create_course(course: CourseCreate):
 
     except Exception as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}") from e
     finally:
         db.close()
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,11 +31,12 @@ dependencies = [
     "pytest-asyncio",
     "pydantic-settings>=2.14.1",
     "slowapi>=0.1.9",
+    "mailtrap>=2.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.2.0",
+    "ruff>=0.4.0",
 ]
 
 [tool.pytest.ini_options]
@@ -46,14 +47,22 @@ asyncio_mode = "auto"
 packages = ["app"]
 
 [tool.ruff]
-line-length = 100
+line-length = 120
 target-version = "py313"
+
+[tool.ruff.lint]
 select = ["E", "F", "B", "I"]
+ignore = ["B008"]  # Depends() in defaults is idiomatic FastAPI
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
 
-[tool.ruff.isort]
-known-first-party = ["app"]
+[dependency-groups]
+dev = [
+    "ruff>=0.4.0",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+
+import bcrypt
+import pytest
+from sqlalchemy import text
+
+from app.models import Courses, UserCourses, Users
+
+from .utils import TestingSessionLocal, engine
+
+
+@pytest.fixture
+def test_user_courses():
+    garmin_course = Courses(
+        id=200,
+        club_name="RTJ Golf Trail at Magnolia Grove",
+        course_name="Falls",
+        address="7001 MAGNOLIA GROVE PKY",
+        city="Mobile",
+        state="Alabama",
+        country="US",
+        latitude=30.740501,
+        longitude=-88.20578,
+    )
+    user_course = UserCourses(id=1, course_id=200, user_id=1, year=2021)
+    db = TestingSessionLocal()
+    db.add(garmin_course)
+    db.add(user_course)
+    db.commit()
+    yield user_course
+    with engine.connect() as con:
+        con.execute(text("DELETE FROM user_courses;"))
+        con.execute(text("DELETE FROM courses;"))
+        con.commit()
+
+
+@pytest.fixture
+def test_user_courses_with_datetime():
+    garmin_course = Courses(
+        id=201,
+        club_name="RTJ Golf Trail at Magnolia Grove",
+        course_name="Falls",
+        address="7001 MAGNOLIA GROVE PKY",
+        city="Mobile",
+        state="Alabama",
+        country="US",
+        latitude=30.740501,
+        longitude=-88.20578,
+        created_at=datetime(2026, 1, 7, 5, 16, 9),
+    )
+    user_course = UserCourses(id=2, course_id=201, user_id=1, year=2024)
+    db = TestingSessionLocal()
+    db.add(garmin_course)
+    db.add(user_course)
+    db.commit()
+    yield user_course
+    with engine.connect() as con:
+        con.execute(text("DELETE FROM user_courses;"))
+        con.execute(text("DELETE FROM courses;"))
+        con.commit()
+
+
+@pytest.fixture
+def test_user():
+    user = Users(
+        id=1,
+        email="georgetest@mail.com",
+        username="georgetest",
+        first_name="firsttest",
+        last_name="lasttest",
+        hashed_password=bcrypt.hashpw(b"password", bcrypt.gensalt()).decode(),
+        is_active=True,
+        role="admin",
+    )
+    db = TestingSessionLocal()
+    db.add(user)
+    db.commit()
+    yield user
+    with engine.connect() as con:
+        con.execute(text("DELETE FROM users;"))
+        con.commit()

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,6 +1,8 @@
-from .utils import *
-from app.dependencies import get_db, get_current_user
 from fastapi import status
+
+from app.dependencies import get_current_user, get_db
+
+from .utils import app, client, override_get_current_user, override_get_db
 
 app.dependency_overrides[get_db] = override_get_db
 app.dependency_overrides[get_current_user] = override_get_current_user

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,10 +1,19 @@
-from .utils import *
-from app.routers.auth import get_db, authenticate_user, create_access_token, SECRET_KEY, ALGORITHM, get_current_user
-from fastapi import status
-from jose import jwt
 from datetime import timedelta
+
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
+from jose import jwt
+
+from app.routers.auth import (
+    ALGORITHM,
+    SECRET_KEY,
+    authenticate_user,
+    create_access_token,
+    get_current_user,
+    get_db,
+)
+
+from .utils import TestingSessionLocal, app, override_get_db
 
 app.dependency_overrides[get_db] = override_get_db
 

--- a/backend/tests/test_garmin_courses.py
+++ b/backend/tests/test_garmin_courses.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
+
 from fastapi import status
+from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,6 +1,7 @@
-from fastapi.testclient import TestClient
-from app.main import app
 from fastapi import status
+from fastapi.testclient import TestClient
+
+from app.main import app
 
 client = TestClient(app)
 

--- a/backend/tests/test_user_courses.py
+++ b/backend/tests/test_user_courses.py
@@ -1,6 +1,8 @@
-from app.dependencies import get_db, get_current_user
 from fastapi import status
-from .utils import *
+
+from app.dependencies import get_current_user, get_db
+
+from .utils import app, client, override_get_current_user, override_get_db
 
 app.dependency_overrides[get_db] = override_get_db
 app.dependency_overrides[get_current_user] = override_get_current_user
@@ -12,6 +14,7 @@ def test_readall_authenticated(test_user_courses):
     assert response.json() == [
         {
             "id": 200,
+            "user_course_id": None,
             "display_name": "RTJ Golf Trail at Magnolia Grove - Falls",
             "club_name": "RTJ Golf Trail at Magnolia Grove",
             "course_name": "Falls",

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,18 +1,13 @@
-from app.dependencies import get_db, get_current_user
+import bcrypt
 from fastapi import status
-from .utils import *
+
+from app.dependencies import get_current_user, get_db
+from app.models import Users
+
+from .utils import TestingSessionLocal, app, client, override_get_current_user, override_get_db
 
 app.dependency_overrides[get_db] = override_get_db
 app.dependency_overrides[get_current_user] = override_get_current_user
-
-# id = Column(Integer, primary_key=True, index=True)
-# email = Column(String, unique=True)
-# username = Column(String, unique=True)
-# first_name = Column(String)
-# last_name = Column(String)
-# hashed_password = Column(String)
-# is_active = Column(Boolean, default=True)
-# role = Column(String)
 
 
 def test_return_user(test_user):
@@ -23,7 +18,7 @@ def test_return_user(test_user):
     assert response.json()["first_name"] == "firsttest"
     assert response.json()["last_name"] == "lasttest"
     assert response.json()["role"] == "admin"
-    assert response.json()["is_active"] == True
+    assert response.json()["is_active"]
 
 
 def test_password_change_success(test_user):

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,14 +1,10 @@
-from datetime import datetime
-from sqlalchemy import create_engine, text
-from sqlalchemy.pool import StaticPool
-from sqlalchemy.orm import sessionmaker
 from fastapi.testclient import TestClient
-import pytest
-from app.main import app
-from app.database import Base
-from app.models import UserCourses, Users, Courses
-import bcrypt
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
+from app.database import Base
+from app.main import app
 
 SQLALCHEMY_DATABASE_URL = "sqlite://"
 engine = create_engine(
@@ -34,75 +30,3 @@ def override_get_current_user():
 
 
 client = TestClient(app)
-
-
-@pytest.fixture
-def test_user_courses():
-    garmin_course = Courses(
-        id=200,
-        club_name="RTJ Golf Trail at Magnolia Grove",
-        course_name="Falls",
-        address="7001 MAGNOLIA GROVE PKY",
-        city="Mobile",
-        state="Alabama",
-        country="US",
-        latitude=30.740501,
-        longitude=-88.20578,
-    )
-    user_course = UserCourses(id=1, course_id=200, user_id=1, year=2021)
-    db = TestingSessionLocal()
-    db.add(garmin_course)
-    db.add(user_course)
-    db.commit()
-    yield user_course
-    with engine.connect() as con:
-        con.execute(text("DELETE FROM user_courses;"))
-        con.execute(text("DELETE FROM courses;"))
-        con.commit()
-
-
-@pytest.fixture
-def test_user_courses_with_datetime():
-    garmin_course = Courses(
-        id=201,
-        club_name="RTJ Golf Trail at Magnolia Grove",
-        course_name="Falls",
-        address="7001 MAGNOLIA GROVE PKY",
-        city="Mobile",
-        state="Alabama",
-        country="US",
-        latitude=30.740501,
-        longitude=-88.20578,
-        created_at=datetime(2026, 1, 7, 5, 16, 9),
-    )
-    user_course = UserCourses(id=2, course_id=201, user_id=1, year=2024)
-    db = TestingSessionLocal()
-    db.add(garmin_course)
-    db.add(user_course)
-    db.commit()
-    yield user_course
-    with engine.connect() as con:
-        con.execute(text("DELETE FROM user_courses;"))
-        con.execute(text("DELETE FROM courses;"))
-        con.commit()
-
-
-@pytest.fixture
-def test_user():
-    user = Users(
-        id=1,
-        email="georgetest@mail.com",
-        username="georgetest",
-        first_name="firsttest",
-        last_name="lasttest",
-        hashed_password=bcrypt.hashpw(b"password", bcrypt.gensalt()).decode(),
-        is_active=True,
-        role="admin",
-    )
-    db = TestingSessionLocal()
-    db.add(user)
-    db.commit()
-    yield user
-    with engine.connect() as con:
-        con.execute(text("DELETE FROM users;"))
-        con.commit()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -312,6 +312,7 @@ dependencies = [
     { name = "folium" },
     { name = "geopy" },
     { name = "httpx" },
+    { name = "mailtrap" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -334,6 +335,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bcrypt" },
@@ -344,6 +350,7 @@ requires-dist = [
     { name = "folium" },
     { name = "geopy" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mailtrap", specifier = ">=2.0.0" },
     { name = "pandas", specifier = ">=2.0,<2.3" },
     { name = "psycopg2-binary" },
     { name = "pydantic", specifier = ">=2.3.0" },
@@ -354,7 +361,7 @@ requires-dist = [
     { name = "python-jose" },
     { name = "python-multipart" },
     { name = "requests" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "sentry-sdk", extras = ["fastapi"] },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=1.4.0" },
@@ -362,6 +369,9 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.23.2" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.4.0" }]
 
 [[package]]
 name = "greenlet"
@@ -479,6 +489,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
+name = "mailtrap"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/75/568f03714c42e8e3bee14a52711adbfc3556e5dea2ed7142b031578d6529/mailtrap-2.6.0.tar.gz", hash = "sha256:990b4f21c75f7a1cdfce6802b9a50ab31b9cdf6071402a15dda882fd0bb56857", size = 31028, upload-time = "2026-05-14T13:51:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/fe/15644d532361e8a277e9afddeff161c7f2cb9b98024130318a2b37b49a0b/mailtrap-2.6.0-py3-none-any.whl", hash = "sha256:764624917c5999790e42827cf03e4e3652008c5a9e3ab08e97f480a923dc0315", size = 46563, upload-time = "2026-05-14T13:51:00.764Z" },
 ]
 
 [[package]]

--- a/frontend/src/components/ForgotPassword.jsx
+++ b/frontend/src/components/ForgotPassword.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../services/api';
+
+function ForgotPassword() {
+    const [email, setEmail] = useState('');
+    const [submitted, setSubmitted] = useState(false);
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setError('');
+        setLoading(true);
+        api.post('/auth/forgot-password', { email })
+            .then(() => setSubmitted(true))
+            .catch(() => setError('Something went wrong. Please try again.'))
+            .finally(() => setLoading(false));
+    };
+
+    return (
+        <div className="login-shell">
+            <div className="login-hero">
+                <div className="login-hero-logo">⛳ GolfMapper</div>
+                <div>
+                    <div className="login-hero-tagline">
+                        Forgot your<br />password?
+                    </div>
+                    <div className="login-hero-sub">
+                        No worries — we'll send you a reset link.
+                    </div>
+                </div>
+            </div>
+
+            <div className="login-form-panel">
+                <div>
+                    <div className="login-form-title">Reset password</div>
+                    <div className="login-form-subtitle">Enter your account email address</div>
+                </div>
+
+                {submitted ? (
+                    <div>
+                        <div className="alert-success" role="alert">
+                            If that email is registered, a reset link has been sent. Check your inbox.
+                        </div>
+                        <div className="login-footer-link" style={{ marginTop: '1rem' }}>
+                            <Link to="/">← Back to sign in</Link>
+                        </div>
+                    </div>
+                ) : (
+                    <>
+                        {error && <div className="alert-danger" role="alert">{error}</div>}
+                        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                            <div className="form-group">
+                                <label className="form-label" htmlFor="forgot-email">Email address</label>
+                                <input
+                                    id="forgot-email"
+                                    className="form-input"
+                                    type="email"
+                                    value={email}
+                                    onChange={e => setEmail(e.target.value)}
+                                    placeholder="you@example.com"
+                                    autoComplete="email"
+                                    required
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                className="btn-primary"
+                                style={{ width: '100%', justifyContent: 'center', padding: '11px' }}
+                                disabled={loading}
+                            >
+                                {loading ? 'Sending…' : 'Send reset link'}
+                            </button>
+                        </form>
+                        <div className="login-footer-link">
+                            <Link to="/">← Back to sign in</Link>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default ForgotPassword;

--- a/frontend/src/components/LoginPage.jsx
+++ b/frontend/src/components/LoginPage.jsx
@@ -86,6 +86,9 @@ function LoginPage() {
                     </button>
                 </form>
 
+                <div className="login-footer-link" style={{ textAlign: 'center' }}>
+                    <Link to="/forgot-password">Forgot password?</Link>
+                </div>
                 <div className="login-footer-link">
                     Don't have an account? <Link to="/register">Create one free →</Link>
                 </div>

--- a/frontend/src/components/ResetPassword.jsx
+++ b/frontend/src/components/ResetPassword.jsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import api from '../services/api';
+
+function ResetPassword() {
+    const [searchParams] = useSearchParams();
+    const token = searchParams.get('token');
+
+    const [password, setPassword] = useState('');
+    const [confirm, setConfirm] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setError('');
+
+        if (password.length < 8) {
+            setError('Password must be at least 8 characters.');
+            return;
+        }
+        if (password !== confirm) {
+            setError('Passwords do not match.');
+            return;
+        }
+
+        setLoading(true);
+        api.post('/auth/reset-password', { token, new_password: password })
+            .then(() => setSuccess(true))
+            .catch(err => {
+                const detail = err.response?.data?.detail;
+                setError(detail || 'Something went wrong. Please try again.');
+            })
+            .finally(() => setLoading(false));
+    };
+
+    if (!token) {
+        return (
+            <div className="login-shell">
+                <div className="login-hero">
+                    <div className="login-hero-logo">⛳ GolfMapper</div>
+                </div>
+                <div className="login-form-panel">
+                    <div className="login-form-title">Invalid link</div>
+                    <div className="alert-danger" role="alert">This reset link is missing a token.</div>
+                    <div className="login-footer-link"><Link to="/">← Back to sign in</Link></div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="login-shell">
+            <div className="login-hero">
+                <div className="login-hero-logo">⛳ GolfMapper</div>
+                <div>
+                    <div className="login-hero-tagline">
+                        Set a new<br />password
+                    </div>
+                    <div className="login-hero-sub">
+                        Choose something strong and memorable.
+                    </div>
+                </div>
+            </div>
+
+            <div className="login-form-panel">
+                <div>
+                    <div className="login-form-title">New password</div>
+                    <div className="login-form-subtitle">Minimum 8 characters</div>
+                </div>
+
+                {success ? (
+                    <div>
+                        <div className="alert-success" role="alert">
+                            Password updated! You can now sign in with your new password.
+                        </div>
+                        <div className="login-footer-link" style={{ marginTop: '1rem' }}>
+                            <Link to="/">Sign in →</Link>
+                        </div>
+                    </div>
+                ) : (
+                    <>
+                        {error && <div className="alert-danger" role="alert">{error}</div>}
+                        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                            <div className="form-group">
+                                <label className="form-label" htmlFor="reset-password">New password</label>
+                                <input
+                                    id="reset-password"
+                                    className="form-input"
+                                    type="password"
+                                    value={password}
+                                    onChange={e => setPassword(e.target.value)}
+                                    placeholder="••••••••"
+                                    autoComplete="new-password"
+                                    required
+                                />
+                            </div>
+                            <div className="form-group">
+                                <label className="form-label" htmlFor="reset-confirm">Confirm password</label>
+                                <input
+                                    id="reset-confirm"
+                                    className="form-input"
+                                    type="password"
+                                    value={confirm}
+                                    onChange={e => setConfirm(e.target.value)}
+                                    placeholder="••••••••"
+                                    autoComplete="new-password"
+                                    required
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                className="btn-primary"
+                                style={{ width: '100%', justifyContent: 'center', padding: '11px' }}
+                                disabled={loading}
+                            >
+                                {loading ? 'Saving…' : 'Set new password'}
+                            </button>
+                        </form>
+                        <div className="login-footer-link">
+                            <Link to="/">← Back to sign in</Link>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default ResetPassword;

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -13,6 +13,8 @@ import UserProfile from './components/UserProfile';
 import AdminUsers from './components/AdminUsers';
 import AdminAddCourse from './components/AdminAddCourse';
 import AdminEditCourse from './components/AdminEditCourse';
+import ForgotPassword from './components/ForgotPassword';
+import ResetPassword from './components/ResetPassword';
 
 const router = createBrowserRouter([
     {
@@ -20,6 +22,8 @@ const router = createBrowserRouter([
         children: [
             { path: '/', element: <LoginPage /> },
             { path: '/register', element: <NewUser /> },
+            { path: '/forgot-password', element: <ForgotPassword /> },
+            { path: '/reset-password', element: <ResetPassword /> },
         ],
     },
     {


### PR DESCRIPTION
## Summary
- New `POST /auth/forgot-password` and `POST /auth/reset-password` endpoints backed by a `PasswordResetToken` DB model
- Tokens are SHA-256 hashed, expire in 15 minutes, and prior unused tokens for the user are invalidated on each new request
- Mailtrap delivers the reset email; if delivery fails the token is rolled back so the user can retry cleanly
- Anti-enumeration: both endpoints always return 200 regardless of whether the email is registered
- Rate-limited: 5/min on forgot-password, 10/min on reset-password
- ForgotPassword and ResetPassword pages added to the React frontend and wired into the router
- "Forgot password?" link added to the login page
- Ruff import-order cleanup across all routers and tests (unrelated to feature)

## Test plan
- [ ] Request reset for a registered email → receive email with working link
- [ ] Request reset for an unregistered email → same 200 response, no email sent
- [ ] Use reset link within 15 minutes → password updated, can sign in
- [ ] Use reset link after 15 minutes → "Invalid or expired reset link" error
- [ ] Use reset link a second time after already resetting → rejected as used
- [ ] Request two resets back-to-back → only the second link works (first invalidated)
- [ ] Navigate to /reset-password with no token param → "Invalid link" screen shown
- [ ] Submit reset with password < 8 chars → inline validation error