### PR TITLE
Add course edit request workflow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from app.config import settings
 from app.database import engine
 from app.limiter import limiter
 from app.models import Base
-from app.routers import admin, auth, garmin_courses, map, password_reset, user_courses, users
+from app.routers import admin, auth, course_requests, garmin_courses, map, password_reset, user_courses, users
 
 try:
     import sentry_sdk
@@ -95,6 +95,7 @@ app.include_router(users.router, prefix=API_PREFIX)
 app.include_router(user_courses.router, prefix=API_PREFIX)
 app.include_router(map.router, prefix=API_PREFIX)
 app.include_router(password_reset.router, prefix=API_PREFIX)
+app.include_router(course_requests.router, prefix=API_PREFIX)
 
 # --- Static assets ---
 if assets_path.exists() and assets_path.is_dir():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,43 @@ class UserCourses(Base):
     )
 
 
+class CourseRequests(Base):
+    __tablename__ = "course_requests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    request_type = Column(String, nullable=False)   # "new_course" | "location_change"
+    status = Column(String, default="pending", nullable=False)  # "pending" | "approved" | "rejected"
+
+    submitted_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    # Only for location_change
+    course_id = Column(Integer, ForeignKey("courses.id"), nullable=True)
+    original_latitude = Column(Float, nullable=True)
+    original_longitude = Column(Float, nullable=True)
+
+    # Proposed values (all fields for new_course; lat/lng for location_change)
+    club_name = Column(String, nullable=True)
+    course_name = Column(String, nullable=True)
+    address = Column(String, nullable=True)
+    city = Column(String, nullable=True)
+    state = Column(String, nullable=True)
+    country = Column(String, nullable=True)
+    latitude = Column(Float, nullable=False)
+    longitude = Column(Float, nullable=False)
+
+    # Admin review
+    reviewed_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    review_message = Column(String, nullable=True)
+    reviewed_at = Column(DateTime, nullable=True)
+
+    created_at = Column(DateTime, default=_now)
+    updated_at = Column(DateTime, default=_now, onupdate=_now)
+
+    submitted_by = relationship("Users", foreign_keys=[submitted_by_user_id])
+    reviewed_by = relationship("Users", foreign_keys=[reviewed_by_user_id])
+    course = relationship("Courses", foreign_keys=[course_id])
+
+
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -120,7 +120,7 @@ class CourseRequests(Base):
     reviewed_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     review_message = Column(String, nullable=True)
     reviewed_at = Column(DateTime, nullable=True)
-    approved_course_id = Column(Integer, nullable=True)  # ID of course created on new_course approval
+    approved_course_id = Column(Integer, ForeignKey("courses.id"), nullable=True)
 
     created_at = Column(DateTime, default=_now)
     updated_at = Column(DateTime, default=_now, onupdate=_now)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -120,6 +120,7 @@ class CourseRequests(Base):
     reviewed_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     review_message = Column(String, nullable=True)
     reviewed_at = Column(DateTime, nullable=True)
+    approved_course_id = Column(Integer, nullable=True)  # ID of course created on new_course approval
 
     created_at = Column(DateTime, default=_now)
     updated_at = Column(DateTime, default=_now, onupdate=_now)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette import status
 
 from app.dependencies import db_dependency, user_dependency
-from app.models import Courses, Users
+from app.models import CourseRequests, Courses, Users
 from app.routers.garmin_courses import CourseBase
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -77,6 +77,11 @@ async def delete_course(user: user_dependency, db: db_dependency, course_id: int
     course_model = db.query(Courses).filter(Courses.id == course_id).first()
     if course_model is None:
         raise HTTPException(status_code=404, detail="Course not found")
+    db.query(CourseRequests).filter(
+        (CourseRequests.course_id == course_id) |
+        (CourseRequests.approved_course_id == course_id),
+        CourseRequests.status == "approved",
+    ).delete(synchronize_session=False)
     db.delete(course_model)
     db.commit()
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -47,6 +47,15 @@ class LocationUpdate(BaseModel):
     longitude: float = Field(..., ge=-180.0, le=180.0)
 
 
+class CourseInfoUpdate(BaseModel):
+    club_name: str | None = None
+    course_name: str | None = None
+    address: str | None = None
+    city: str | None = None
+    state: str | None = None
+    country: str | None = None
+
+
 @router.get("/")
 async def root(user: user_dependency):
     if user is None or user.get("role") != "admin":
@@ -88,6 +97,25 @@ async def create_course(user: user_dependency, db: db_dependency, course_data: C
         created_at=datetime.now(timezone.utc),
     )
     db.add(course)
+    db.commit()
+    db.refresh(course)
+    return course
+
+
+@router.put("/courses/{course_id}/info", status_code=status.HTTP_200_OK, response_model=CourseBase)
+async def update_course_info(
+    user: user_dependency,
+    db: db_dependency,
+    info: CourseInfoUpdate,
+    course_id: int = Path(ge=1),
+):
+    if user is None or user.get("role") != "admin":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    course = db.query(Courses).filter(Courses.id == course_id).first()
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    for field, value in info.model_dump(exclude_unset=True).items():
+        setattr(course, field, value)
     db.commit()
     db.refresh(course)
     return course

--- a/backend/app/routers/course_requests.py
+++ b/backend/app/routers/course_requests.py
@@ -1,0 +1,231 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Path
+from pydantic import BaseModel, ConfigDict, Field
+from starlette import status as http_status
+
+from app.dependencies import db_dependency, user_dependency
+from app.models import Courses, CourseRequests, UserCourses
+
+router = APIRouter(prefix="/course-requests", tags=["course-requests"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+class NewCourseRequest(BaseModel):
+    club_name: str | None = None
+    course_name: str | None = None
+    address: str | None = None
+    city: str | None = None
+    state: str | None = None
+    country: str | None = None
+    latitude: float = Field(..., ge=-90.0, le=90.0)
+    longitude: float = Field(..., ge=-180.0, le=180.0)
+
+
+class LocationChangeRequest(BaseModel):
+    course_id: int = Field(..., ge=1)
+    latitude: float = Field(..., ge=-90.0, le=90.0)
+    longitude: float = Field(..., ge=-180.0, le=180.0)
+
+
+class RejectBody(BaseModel):
+    message: str = Field(..., min_length=1)
+
+
+class CourseRequestOut(BaseModel):
+    id: int
+    request_type: str
+    status: str
+    course_id: int | None
+    club_name: str | None
+    course_name: str | None
+    address: str | None
+    city: str | None
+    state: str | None
+    country: str | None
+    latitude: float
+    longitude: float
+    original_latitude: float | None
+    original_longitude: float | None
+    review_message: str | None
+    reviewed_at: datetime | None
+    created_at: datetime | None
+    # Resolved display name for location_change requests
+    course_display_name: str | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+def _to_out(req: CourseRequests) -> CourseRequestOut:
+    data = CourseRequestOut.model_validate(req)
+    if req.course:
+        data.course_display_name = req.course.display_name
+    return data
+
+
+# ---------------------------------------------------------------------------
+# User endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/new-course", status_code=http_status.HTTP_201_CREATED, response_model=CourseRequestOut)
+async def submit_new_course(user: user_dependency, db: db_dependency, body: NewCourseRequest):
+    if user is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    req = CourseRequests(
+        request_type="new_course",
+        submitted_by_user_id=user["id"],
+        club_name=body.club_name,
+        course_name=body.course_name,
+        address=body.address,
+        city=body.city,
+        state=body.state,
+        country=body.country,
+        latitude=body.latitude,
+        longitude=body.longitude,
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return _to_out(req)
+
+
+@router.post("/location-change", status_code=http_status.HTTP_201_CREATED, response_model=CourseRequestOut)
+async def submit_location_change(user: user_dependency, db: db_dependency, body: LocationChangeRequest):
+    if user is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    course = db.query(Courses).filter(Courses.id == body.course_id).first()
+    if course is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    existing = (
+        db.query(CourseRequests)
+        .filter(
+            CourseRequests.submitted_by_user_id == user["id"],
+            CourseRequests.request_type == "location_change",
+            CourseRequests.course_id == body.course_id,
+            CourseRequests.status == "pending",
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="You already have a pending location change request for this course.",
+        )
+
+    req = CourseRequests(
+        request_type="location_change",
+        submitted_by_user_id=user["id"],
+        course_id=body.course_id,
+        original_latitude=course.latitude,
+        original_longitude=course.longitude,
+        latitude=body.latitude,
+        longitude=body.longitude,
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return _to_out(req)
+
+
+@router.get("/my-requests", status_code=http_status.HTTP_200_OK, response_model=list[CourseRequestOut])
+async def my_requests(user: user_dependency, db: db_dependency):
+    if user is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    rows = (
+        db.query(CourseRequests)
+        .filter(CourseRequests.submitted_by_user_id == user["id"])
+        .order_by(CourseRequests.created_at.desc())
+        .all()
+    )
+    return [_to_out(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+def _require_admin(user):
+    if user is None or user.get("role") != "admin":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@router.get("/admin/all", status_code=http_status.HTTP_200_OK, response_model=list[CourseRequestOut])
+async def admin_list_requests(user: user_dependency, db: db_dependency, pending_only: bool = True):
+    _require_admin(user)
+    q = db.query(CourseRequests)
+    if pending_only:
+        q = q.filter(CourseRequests.status == "pending")
+    rows = q.order_by(CourseRequests.created_at.asc()).all()
+    return [_to_out(r) for r in rows]
+
+
+@router.post("/admin/{request_id}/approve", status_code=http_status.HTTP_200_OK, response_model=CourseRequestOut)
+async def admin_approve(user: user_dependency, db: db_dependency, request_id: int = Path(ge=1)):
+    _require_admin(user)
+    req = db.query(CourseRequests).filter(CourseRequests.id == request_id).first()
+    if req is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if req.status != "pending":
+        raise HTTPException(status_code=409, detail="Request is no longer pending")
+
+    if req.request_type == "new_course":
+        course = Courses(
+            club_name=req.club_name,
+            course_name=req.course_name,
+            address=req.address,
+            city=req.city,
+            state=req.state,
+            country=req.country,
+            latitude=req.latitude,
+            longitude=req.longitude,
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(course)
+        db.flush()  # get course.id before committing
+        user_course = UserCourses(
+            course_id=course.id,
+            user_id=req.submitted_by_user_id,
+            year=None,
+        )
+        db.add(user_course)
+
+    elif req.request_type == "location_change":
+        course = db.query(Courses).filter(Courses.id == req.course_id).first()
+        if course is None:
+            raise HTTPException(status_code=404, detail="Target course no longer exists")
+        course.latitude = req.latitude
+        course.longitude = req.longitude
+
+    req.status = "approved"
+    req.reviewed_by_user_id = user["id"]
+    req.reviewed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(req)
+    return _to_out(req)
+
+
+@router.post("/admin/{request_id}/reject", status_code=http_status.HTTP_200_OK, response_model=CourseRequestOut)
+async def admin_reject(
+    user: user_dependency,
+    db: db_dependency,
+    body: RejectBody,
+    request_id: int = Path(ge=1),
+):
+    _require_admin(user)
+    req = db.query(CourseRequests).filter(CourseRequests.id == request_id).first()
+    if req is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if req.status != "pending":
+        raise HTTPException(status_code=409, detail="Request is no longer pending")
+
+    req.status = "rejected"
+    req.review_message = body.message
+    req.reviewed_by_user_id = user["id"]
+    req.reviewed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(req)
+    return _to_out(req)

--- a/backend/app/routers/course_requests.py
+++ b/backend/app/routers/course_requests.py
@@ -60,6 +60,7 @@ class CourseRequestOut(BaseModel):
     original_longitude: float | None
     review_message: str | None
     reviewed_at: datetime | None
+    approved_course_id: int | None = None
     created_at: datetime | None
     # Resolved display name for location_change requests
     course_display_name: str | None = None
@@ -207,6 +208,7 @@ async def admin_approve(user: user_dependency, db: db_dependency, request_id: in
             year=None,
         )
         db.add(user_course)
+        req.approved_course_id = course.id
 
     elif req.request_type == "location_change":
         course = db.query(Courses).filter(Courses.id == req.course_id).first()

--- a/backend/app/routers/course_requests.py
+++ b/backend/app/routers/course_requests.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Path
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from starlette import status as http_status
+
+from sqlalchemy.exc import IntegrityError
 
 from app.dependencies import db_dependency, user_dependency
 from app.models import Courses, CourseRequests, UserCourses
@@ -23,6 +25,12 @@ class NewCourseRequest(BaseModel):
     country: str | None = None
     latitude: float = Field(..., ge=-90.0, le=90.0)
     longitude: float = Field(..., ge=-180.0, le=180.0)
+
+    @model_validator(mode='after')
+    def require_at_least_one_name(self):
+        if not (self.club_name and self.club_name.strip()) and not (self.course_name and self.course_name.strip()):
+            raise ValueError('Either club_name or course_name is required')
+        return self
 
 
 class LocationChangeRequest(BaseModel):
@@ -125,9 +133,16 @@ async def submit_location_change(user: user_dependency, db: db_dependency, body:
         latitude=body.latitude,
         longitude=body.longitude,
     )
-    db.add(req)
-    db.commit()
-    db.refresh(req)
+    try:
+        db.add(req)
+        db.commit()
+        db.refresh(req)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="You already have a pending location change request for this course.",
+        )
     return _to_out(req)
 
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -38,3 +38,45 @@ def test_admin_delete_course_not_found():
     response = client.delete("/api/v1/admin/courses/99999")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {"detail": "Course not found"}
+
+
+# ── Edit course info ──────────────────────────────────────────────────────────
+
+def test_admin_update_course_info(test_user_courses):
+    response = client.put("/api/v1/admin/courses/200/info", json={
+        "club_name": "Updated Club",
+        "course_name": "Updated Course",
+        "city": "New City",
+        "state": "CA",
+        "country": "US",
+    })
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["club_name"] == "Updated Club"
+    assert data["course_name"] == "Updated Course"
+    assert data["city"] == "New City"
+    assert data["state"] == "CA"
+
+
+def test_admin_update_course_info_partial(test_user_courses):
+    response = client.put("/api/v1/admin/courses/200/info", json={"city": "Partial City"})
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["city"] == "Partial City"
+    # Other fields unchanged
+    assert data["club_name"] == "RTJ Golf Trail at Magnolia Grove"
+
+
+def test_admin_update_course_info_not_found():
+    response = client.put("/api/v1/admin/courses/99999/info", json={"city": "Nowhere"})
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "Course not found"}
+
+
+def test_admin_update_course_info_non_admin(test_user_courses):
+    app.dependency_overrides[get_current_user] = lambda: {"username": "other", "id": 2, "role": "user"}
+    try:
+        response = client.put("/api/v1/admin/courses/200/info", json={"city": "Sneaky"})
+    finally:
+        app.dependency_overrides[get_current_user] = override_get_current_user
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/test_course_requests.py
+++ b/backend/tests/test_course_requests.py
@@ -1,0 +1,286 @@
+import bcrypt
+import pytest
+from fastapi import status
+from sqlalchemy import text
+
+from app.dependencies import get_current_user, get_db
+from app.models import Courses, CourseRequests, UserCourses, Users
+
+from .utils import TestingSessionLocal, app, client, engine, override_get_current_user, override_get_db
+
+app.dependency_overrides[get_db] = override_get_db
+app.dependency_overrides[get_current_user] = override_get_current_user
+
+# override_get_current_user returns id=1, role="admin"
+ADMIN_USER = {"username": "georgetest", "id": 1, "role": "admin"}
+NORMAL_USER = {"username": "normaluser", "id": 2, "role": "user"}
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def clean_requests():
+    """Wipe course_requests (and dependent tables) between every test."""
+    yield
+    with engine.connect() as con:
+        con.execute(text("DELETE FROM course_requests;"))
+        con.execute(text("DELETE FROM user_courses;"))
+        con.execute(text("DELETE FROM courses;"))
+        con.execute(text("DELETE FROM users;"))
+        con.commit()
+
+
+@pytest.fixture
+def admin_user():
+    user = Users(
+        id=1, email="admin@test.com", username="georgetest",
+        first_name="Admin", last_name="User",
+        hashed_password=bcrypt.hashpw(b"password", bcrypt.gensalt()).decode(),
+        is_active=True, role="admin",
+    )
+    db = TestingSessionLocal()
+    db.add(user)
+    db.commit()
+    return user
+
+
+@pytest.fixture
+def normal_user():
+    user = Users(
+        id=2, email="normal@test.com", username="normaluser",
+        first_name="Normal", last_name="User",
+        hashed_password=bcrypt.hashpw(b"password", bcrypt.gensalt()).decode(),
+        is_active=True, role="user",
+    )
+    db = TestingSessionLocal()
+    db.add(user)
+    db.commit()
+    return user
+
+
+@pytest.fixture
+def existing_course():
+    course = Courses(
+        id=300, club_name="Test Club", course_name="Test Course",
+        city="Testville", state="TX", country="US",
+        latitude=30.0, longitude=-97.0,
+    )
+    db = TestingSessionLocal()
+    db.add(course)
+    db.commit()
+    return course
+
+
+# ── Submit new course ─────────────────────────────────────────────────────────
+
+def test_submit_new_course(admin_user):
+    resp = client.post("/api/v1/course-requests/new-course", json={
+        "club_name": "New Club",
+        "course_name": "New Course",
+        "city": "Dallas",
+        "state": "TX",
+        "country": "US",
+        "latitude": 32.7767,
+        "longitude": -96.7970,
+    })
+    assert resp.status_code == status.HTTP_201_CREATED
+    data = resp.json()
+    assert data["request_type"] == "new_course"
+    assert data["status"] == "pending"
+    assert data["latitude"] == pytest.approx(32.7767)
+    assert data["club_name"] == "New Club"
+
+
+def test_submit_new_course_unauthenticated():
+    app.dependency_overrides[get_current_user] = lambda: None
+    resp = client.post("/api/v1/course-requests/new-course", json={
+        "latitude": 32.0, "longitude": -97.0,
+    })
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ── Submit location change ────────────────────────────────────────────────────
+
+def test_submit_location_change(admin_user, existing_course):
+    resp = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300,
+        "latitude": 31.0,
+        "longitude": -96.0,
+    })
+    assert resp.status_code == status.HTTP_201_CREATED
+    data = resp.json()
+    assert data["request_type"] == "location_change"
+    assert data["status"] == "pending"
+    assert data["course_id"] == 300
+    assert data["original_latitude"] == pytest.approx(30.0)
+    assert data["original_longitude"] == pytest.approx(-97.0)
+    assert data["latitude"] == pytest.approx(31.0)
+
+
+def test_submit_location_change_course_not_found(admin_user):
+    resp = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 9999,
+        "latitude": 31.0,
+        "longitude": -96.0,
+    })
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_submit_location_change_duplicate_pending_blocked(admin_user, existing_course):
+    payload = {"course_id": 300, "latitude": 31.0, "longitude": -96.0}
+    client.post("/api/v1/course-requests/location-change", json=payload)
+    resp = client.post("/api/v1/course-requests/location-change", json=payload)
+    assert resp.status_code == status.HTTP_409_CONFLICT
+    assert "pending" in resp.json()["detail"].lower()
+
+
+# ── My requests ───────────────────────────────────────────────────────────────
+
+def test_my_requests_only_own(admin_user, normal_user, existing_course):
+    # Admin user (id=1) submits one request
+    client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+
+    # Switch to normal user (id=2) who submits a different request
+    app.dependency_overrides[get_current_user] = lambda: NORMAL_USER
+    client.post("/api/v1/course-requests/new-course", json={
+        "club_name": "Other Club", "latitude": 29.0, "longitude": -95.0,
+    })
+
+    # Normal user should only see their own request
+    resp = client.get("/api/v1/course-requests/my-requests")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["request_type"] == "new_course"
+    assert data[0]["club_name"] == "Other Club"
+
+
+# ── Admin approve ─────────────────────────────────────────────────────────────
+
+def test_admin_approve_new_course_creates_course_and_user_courses(admin_user):
+    submit = client.post("/api/v1/course-requests/new-course", json={
+        "club_name": "Approved Club", "course_name": "Approved Course",
+        "city": "Houston", "state": "TX", "country": "US",
+        "latitude": 29.7604, "longitude": -95.3698,
+    })
+    req_id = submit.json()["id"]
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/approve")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["status"] == "approved"
+
+    # Course should now exist in the DB
+    db = TestingSessionLocal()
+    course = db.query(Courses).filter(Courses.club_name == "Approved Club").first()
+    assert course is not None
+    assert course.latitude == pytest.approx(29.7604)
+
+    # And be added to the submitting user's course list
+    uc = db.query(UserCourses).filter(UserCourses.course_id == course.id, UserCourses.user_id == 1).first()
+    assert uc is not None
+    assert uc.year is None
+    db.close()
+
+
+def test_admin_approve_location_change_updates_course(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.5, "longitude": -96.5,
+    })
+    req_id = submit.json()["id"]
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/approve")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["status"] == "approved"
+
+    db = TestingSessionLocal()
+    course = db.query(Courses).filter(Courses.id == 300).first()
+    assert course.latitude == pytest.approx(31.5)
+    assert course.longitude == pytest.approx(-96.5)
+    db.close()
+
+
+def test_admin_approve_already_actioned_returns_409(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.5, "longitude": -96.5,
+    })
+    req_id = submit.json()["id"]
+    client.post(f"/api/v1/course-requests/admin/{req_id}/approve")
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/approve")
+    assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+# ── Admin reject ──────────────────────────────────────────────────────────────
+
+def test_admin_reject_stores_message(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+    req_id = submit.json()["id"]
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={
+        "message": "Location appears incorrect."
+    })
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    assert data["status"] == "rejected"
+    assert data["review_message"] == "Location appears incorrect."
+
+
+def test_admin_reject_requires_message(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+    req_id = submit.json()["id"]
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={"message": ""})
+    assert resp.status_code == 422
+
+
+def test_admin_reject_already_actioned_returns_409(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+    req_id = submit.json()["id"]
+    client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={"message": "No."})
+
+    resp = client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={"message": "Again."})
+    assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+# ── Admin list ────────────────────────────────────────────────────────────────
+
+def test_admin_list_pending_only_by_default(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+    req_id = submit.json()["id"]
+    client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={"message": "No."})
+
+    resp = client.get("/api/v1/course-requests/admin/all")
+    assert resp.status_code == status.HTTP_200_OK
+    # Rejected request should not appear in default pending-only view
+    assert all(r["status"] == "pending" for r in resp.json())
+
+
+def test_admin_list_all_when_flag_false(admin_user, existing_course):
+    submit = client.post("/api/v1/course-requests/location-change", json={
+        "course_id": 300, "latitude": 31.0, "longitude": -96.0,
+    })
+    req_id = submit.json()["id"]
+    client.post(f"/api/v1/course-requests/admin/{req_id}/reject", json={"message": "No."})
+
+    resp = client.get("/api/v1/course-requests/admin/all?pending_only=false")
+    assert resp.status_code == status.HTTP_200_OK
+    assert any(r["status"] == "rejected" for r in resp.json())
+
+
+def test_non_admin_cannot_access_admin_list(admin_user):
+    app.dependency_overrides[get_current_user] = lambda: NORMAL_USER
+    resp = client.get("/api/v1/course-requests/admin/all")
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/test_course_requests.py
+++ b/backend/tests/test_course_requests.py
@@ -180,13 +180,16 @@ def test_admin_approve_new_course_creates_course_and_user_courses(admin_user):
 
     resp = client.post(f"/api/v1/course-requests/admin/{req_id}/approve")
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()["status"] == "approved"
+    data = resp.json()
+    assert data["status"] == "approved"
+    assert data["approved_course_id"] is not None
 
     # Course should now exist in the DB
     db = TestingSessionLocal()
     course = db.query(Courses).filter(Courses.club_name == "Approved Club").first()
     assert course is not None
     assert course.latitude == pytest.approx(29.7604)
+    assert data["approved_course_id"] == course.id
 
     # And be added to the submitting user's course list
     uc = db.query(UserCourses).filter(UserCourses.course_id == course.id, UserCourses.user_id == 1).first()

--- a/backend/tests/test_course_requests.py
+++ b/backend/tests/test_course_requests.py
@@ -93,11 +93,20 @@ def test_submit_new_course(admin_user):
 
 def test_submit_new_course_unauthenticated():
     app.dependency_overrides[get_current_user] = lambda: None
+    try:
+        resp = client.post("/api/v1/course-requests/new-course", json={
+            "club_name": "Some Club", "latitude": 32.0, "longitude": -97.0,
+        })
+    finally:
+        app.dependency_overrides[get_current_user] = override_get_current_user
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_submit_new_course_requires_name(admin_user):
     resp = client.post("/api/v1/course-requests/new-course", json={
         "latitude": 32.0, "longitude": -97.0,
     })
-    app.dependency_overrides[get_current_user] = override_get_current_user
-    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    assert resp.status_code == 422
 
 
 # ── Submit location change ────────────────────────────────────────────────────
@@ -143,15 +152,15 @@ def test_my_requests_only_own(admin_user, normal_user, existing_course):
         "course_id": 300, "latitude": 31.0, "longitude": -96.0,
     })
 
-    # Switch to normal user (id=2) who submits a different request
+    # Switch to normal user (id=2) who submits a different request and checks their own list
     app.dependency_overrides[get_current_user] = lambda: NORMAL_USER
-    client.post("/api/v1/course-requests/new-course", json={
-        "club_name": "Other Club", "latitude": 29.0, "longitude": -95.0,
-    })
-
-    # Normal user should only see their own request
-    resp = client.get("/api/v1/course-requests/my-requests")
-    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        client.post("/api/v1/course-requests/new-course", json={
+            "club_name": "Other Club", "latitude": 29.0, "longitude": -95.0,
+        })
+        resp = client.get("/api/v1/course-requests/my-requests")
+    finally:
+        app.dependency_overrides[get_current_user] = override_get_current_user
 
     data = resp.json()
     assert len(data) == 1
@@ -281,6 +290,8 @@ def test_admin_list_all_when_flag_false(admin_user, existing_course):
 
 def test_non_admin_cannot_access_admin_list(admin_user):
     app.dependency_overrides[get_current_user] = lambda: NORMAL_USER
-    resp = client.get("/api/v1/course-requests/admin/all")
-    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        resp = client.get("/api/v1/course-requests/admin/all")
+    finally:
+        app.dependency_overrides[get_current_user] = override_get_current_user
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED

--- a/frontend/src/components/AdminEditCourseInfo.jsx
+++ b/frontend/src/components/AdminEditCourseInfo.jsx
@@ -1,0 +1,171 @@
+import React, { useState } from 'react';
+import { Form, Button, Row, Col, Alert, Spinner, Card } from 'react-bootstrap';
+import api from '../services/api';
+
+const FIELDS = [
+    { name: 'club_name',   label: 'Club Name' },
+    { name: 'course_name', label: 'Course Name' },
+    { name: 'address',     label: 'Address' },
+    { name: 'city',        label: 'City' },
+    { name: 'state',       label: 'State / Province' },
+    { name: 'country',     label: 'Country' },
+];
+
+export default function AdminEditCourseInfo() {
+    const [courseId, setCourseId] = useState('');
+    const [course, setCourse] = useState(null);
+    const [form, setForm] = useState({});
+    const [loadAlert, setLoadAlert] = useState(null);
+    const [saveAlert, setSaveAlert] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+
+    const handleLoad = async e => {
+        e.preventDefault();
+        if (!courseId) return;
+        setLoading(true);
+        setLoadAlert(null);
+        setCourse(null);
+        setSaveAlert(null);
+        try {
+            const res = await api.get(`/garmin_courses/course/${courseId}`);
+            const c = res.data;
+            setCourse(c);
+            setForm({
+                club_name:   c.club_name   ?? '',
+                course_name: c.course_name ?? '',
+                address:     c.address     ?? '',
+                city:        c.city        ?? '',
+                state:       c.state       ?? '',
+                country:     c.country     ?? '',
+            });
+        } catch (err) {
+            setLoadAlert(err.response?.status === 404 ? `Course ID ${courseId} not found.` : 'Failed to load course.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleField = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+
+    const handleSave = async e => {
+        e.preventDefault();
+        if (!course) return;
+        setSaving(true);
+        setSaveAlert(null);
+        try {
+            const res = await api.put(`/admin/courses/${course.id}/info`, form);
+            setCourse(res.data);
+            setSaveAlert({ variant: 'success', msg: 'Course information updated successfully.' });
+        } catch (err) {
+            setSaveAlert({ variant: 'danger', msg: err.response?.data?.detail || 'Failed to save changes.' });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!course) return;
+        const confirmed = window.confirm(
+            `Delete "${course.display_name}" (ID ${course.id})?\n\nThis will permanently remove the course and all associated user records. This cannot be undone.`
+        );
+        if (!confirmed) return;
+        setDeleting(true);
+        setSaveAlert(null);
+        try {
+            await api.delete(`/admin/courses/${course.id}`);
+            setCourse(null);
+            setCourseId('');
+            setForm({});
+            setSaveAlert({ variant: 'success', msg: `Course "${course.display_name}" deleted successfully.` });
+        } catch (err) {
+            setSaveAlert({ variant: 'danger', msg: err.response?.data?.detail || 'Failed to delete course.' });
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    return (
+        <div className="p-3">
+            <h4 className="mb-3">Edit Course Information</h4>
+
+            <Form onSubmit={handleLoad} className="mb-3">
+                <Row className="align-items-end g-2">
+                    <Col xs="auto">
+                        <Form.Label>Course ID</Form.Label>
+                        <Form.Control
+                            type="number" min="1" value={courseId}
+                            onChange={e => setCourseId(e.target.value)}
+                            placeholder="Enter course ID"
+                            style={{ width: '160px' }}
+                        />
+                    </Col>
+                    <Col xs="auto">
+                        <Button type="submit" variant="secondary" disabled={loading || !courseId}>
+                            {loading ? <><Spinner size="sm" className="me-1" />Loading…</> : 'Load Course'}
+                        </Button>
+                    </Col>
+                </Row>
+                {loadAlert && <Alert variant="warning" className="mt-2 mb-0">{loadAlert}</Alert>}
+            </Form>
+
+            {saveAlert && !course && (
+                <Alert variant={saveAlert.variant} dismissible onClose={() => setSaveAlert(null)}>
+                    {saveAlert.msg}
+                </Alert>
+            )}
+
+            {course && (
+                <>
+                    <Card className="mb-3">
+                        <Card.Body className="py-2">
+                            <strong>{course.display_name}</strong>
+                            <span className="text-muted ms-2">{[course.city, course.state, course.country].filter(Boolean).join(', ')}</span>
+                            <span className="text-muted ms-3" style={{ fontSize: '0.85rem' }}>ID: {course.id}</span>
+                        </Card.Body>
+                    </Card>
+
+                    {saveAlert && (
+                        <Alert variant={saveAlert.variant} dismissible onClose={() => setSaveAlert(null)}>
+                            {saveAlert.msg}
+                        </Alert>
+                    )}
+
+                    <Form onSubmit={handleSave}>
+                        <Row>
+                            {FIELDS.map(({ name, label }) => (
+                                <Col md={6} key={name} className="mb-3">
+                                    <Form.Group>
+                                        <Form.Label>{label}</Form.Label>
+                                        <Form.Control
+                                            name={name}
+                                            value={form[name] ?? ''}
+                                            onChange={handleField}
+                                            placeholder={label}
+                                        />
+                                    </Form.Group>
+                                </Col>
+                            ))}
+                        </Row>
+
+                        <div className="d-flex justify-content-between align-items-center mt-2">
+                            <Button type="submit" variant="primary" disabled={saving}>
+                                {saving ? <><Spinner size="sm" className="me-1" />Saving…</> : 'Save Changes'}
+                            </Button>
+
+                            <Button
+                                type="button"
+                                variant="danger"
+                                disabled={deleting}
+                                onClick={handleDelete}
+                            >
+                                {deleting ? <><Spinner size="sm" className="me-1" />Deleting…</> : '🗑 Delete Course'}
+                            </Button>
+                        </div>
+                    </Form>
+                </>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/AdminNav.jsx
+++ b/frontend/src/components/AdminNav.jsx
@@ -15,6 +15,9 @@ const AdminNav = () => (
         <NavLink to="/admin/edit-course" className={adminNavLinkClass}>
             Edit Course Location
         </NavLink>
+        <NavLink to="/admin/edit-course-info" className={adminNavLinkClass}>
+            Edit Course Info
+        </NavLink>
         <NavLink to="/admin/review-requests" className={adminNavLinkClass}>
             Review Requests
         </NavLink>

--- a/frontend/src/components/AdminNav.jsx
+++ b/frontend/src/components/AdminNav.jsx
@@ -15,6 +15,9 @@ const AdminNav = () => (
         <NavLink to="/admin/edit-course" className={adminNavLinkClass}>
             Edit Course Location
         </NavLink>
+        <NavLink to="/admin/review-requests" className={adminNavLinkClass}>
+            Review Requests
+        </NavLink>
     </nav>
 );
 

--- a/frontend/src/components/AdminReviewRequests.jsx
+++ b/frontend/src/components/AdminReviewRequests.jsx
@@ -38,7 +38,7 @@ function StatusBadge({ status }) {
 function NewCourseMap({ lat, lng }) {
     return (
         <MapContainer center={[lat, lng]} zoom={12} style={{ height: '200px', borderRadius: '6px' }} zoomControl={false} dragging={false} scrollWheelZoom={false}>
-            <TileLayer attribution='&copy; OpenStreetMap' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            <TileLayer attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
             <Marker position={[lat, lng]} />
         </MapContainer>
     );
@@ -51,7 +51,7 @@ function LocationChangeMap({ origLat, origLng, newLat, newLng }) {
     const midLng = (origLng + newLng) / 2;
     return (
         <MapContainer center={[midLat, midLng]} zoom={11} style={{ height: '200px', borderRadius: '6px' }} zoomControl={false} dragging={false} scrollWheelZoom={false}>
-            <TileLayer attribution='&copy; OpenStreetMap' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            <TileLayer attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
             <Marker position={[origLat, origLng]} icon={blueIcon}>
                 <Tooltip permanent direction="top" offset={[0, -40]}>Original</Tooltip>
             </Marker>
@@ -221,14 +221,16 @@ export default function AdminReviewRequests() {
     const [loading, setLoading] = useState(true);
     const [pendingOnly, setPendingOnly] = useState(true);
     const [error, setError] = useState(null);
+    const fetchSeq = useRef(0);
 
     const fetchRequests = (pendingOnlyFlag) => {
+        const seq = ++fetchSeq.current;
         setLoading(true);
         setError(null);
         api.get(`/course-requests/admin/all?pending_only=${pendingOnlyFlag}`)
-            .then(res => setRequests(res.data))
-            .catch(err => setError(err.response?.data?.detail || 'Failed to load requests.'))
-            .finally(() => setLoading(false));
+            .then(res => { if (seq === fetchSeq.current) setRequests(res.data); })
+            .catch(err => { if (seq === fetchSeq.current) setError(err.response?.data?.detail || 'Failed to load requests.'); })
+            .finally(() => { if (seq === fetchSeq.current) setLoading(false); });
     };
 
     useEffect(() => { fetchRequests(pendingOnly); }, [pendingOnly]);

--- a/frontend/src/components/AdminReviewRequests.jsx
+++ b/frontend/src/components/AdminReviewRequests.jsx
@@ -1,0 +1,275 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { MapContainer, TileLayer, Marker, Tooltip } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Row, Col, Card, Badge, Button, Form, Spinner, Alert } from 'react-bootstrap';
+import api from '../services/api';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+// Blue marker for original location
+const blueIcon = new L.Icon({
+    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-blue.png',
+    iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
+    shadowUrl: markerShadow,
+    iconSize: [25, 41], iconAnchor: [12, 41], popupAnchor: [1, -34], shadowSize: [41, 41],
+});
+
+// Red marker for proposed location
+const redIcon = new L.Icon({
+    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+    iconRetinaUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png',
+    shadowUrl: markerShadow,
+    iconSize: [25, 41], iconAnchor: [12, 41], popupAnchor: [1, -34], shadowSize: [41, 41],
+});
+
+function StatusBadge({ status }) {
+    const map = { pending: 'warning', approved: 'success', rejected: 'danger' };
+    return <Badge bg={map[status] ?? 'secondary'} text={status === 'pending' ? 'dark' : undefined}>{status}</Badge>;
+}
+
+// ── Mini map for new course ───────────────────────────────────────────────────
+
+function NewCourseMap({ lat, lng }) {
+    return (
+        <MapContainer center={[lat, lng]} zoom={12} style={{ height: '200px', borderRadius: '6px' }} zoomControl={false} dragging={false} scrollWheelZoom={false}>
+            <TileLayer attribution='&copy; OpenStreetMap' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            <Marker position={[lat, lng]} />
+        </MapContainer>
+    );
+}
+
+// ── Mini map for location change (before + after) ─────────────────────────────
+
+function LocationChangeMap({ origLat, origLng, newLat, newLng }) {
+    const midLat = (origLat + newLat) / 2;
+    const midLng = (origLng + newLng) / 2;
+    return (
+        <MapContainer center={[midLat, midLng]} zoom={11} style={{ height: '200px', borderRadius: '6px' }} zoomControl={false} dragging={false} scrollWheelZoom={false}>
+            <TileLayer attribution='&copy; OpenStreetMap' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+            <Marker position={[origLat, origLng]} icon={blueIcon}>
+                <Tooltip permanent direction="top" offset={[0, -40]}>Original</Tooltip>
+            </Marker>
+            <Marker position={[newLat, newLng]} icon={redIcon}>
+                <Tooltip permanent direction="top" offset={[0, -40]}>Proposed</Tooltip>
+            </Marker>
+        </MapContainer>
+    );
+}
+
+// ── Request card ──────────────────────────────────────────────────────────────
+
+function RequestCard({ req, onAction }) {
+    const [rejecting, setRejecting] = useState(false);
+    const [rejectMsg, setRejectMsg] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [toast, setToast] = useState(null);
+
+    const handleApprove = async () => {
+        setBusy(true);
+        try {
+            await api.post(`/course-requests/admin/${req.id}/approve`);
+            onAction(req.id, 'approved');
+        } catch (err) {
+            setToast(err.response?.data?.detail || 'Failed to approve.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleReject = async () => {
+        if (!rejectMsg.trim()) return;
+        setBusy(true);
+        try {
+            await api.post(`/course-requests/admin/${req.id}/reject`, { message: rejectMsg });
+            onAction(req.id, 'rejected');
+        } catch (err) {
+            setToast(err.response?.data?.detail || 'Failed to reject.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const isNew = req.request_type === 'new_course';
+    const courseName = isNew
+        ? [req.club_name, req.course_name].filter(Boolean).join(' – ') || 'Unnamed Course'
+        : req.course_display_name || `Course #${req.course_id}`;
+
+    return (
+        <Card className="mb-3">
+            <Card.Header className="d-flex justify-content-between align-items-center">
+                <span><strong>{courseName}</strong></span>
+                <div className="d-flex align-items-center gap-2">
+                    <StatusBadge status={req.status} />
+                    <span className="text-muted" style={{ fontSize: '0.8rem' }}>
+                        {req.created_at ? new Date(req.created_at).toLocaleDateString() : ''}
+                    </span>
+                </div>
+            </Card.Header>
+            <Card.Body>
+                {toast && <Alert variant="danger" dismissible onClose={() => setToast(null)} className="mb-2">{toast}</Alert>}
+                <Row>
+                    <Col md={5}>
+                        {isNew ? (
+                            <>
+                                <div className="mb-2" style={{ fontSize: '0.9rem' }}>
+                                    {req.address && <div><strong>Address:</strong> {req.address}</div>}
+                                    <div>{[req.city, req.state, req.country].filter(Boolean).join(', ')}</div>
+                                    <div className="text-muted mt-1">
+                                        <strong>Lat:</strong> {req.latitude?.toFixed(6)} &nbsp;
+                                        <strong>Lng:</strong> {req.longitude?.toFixed(6)}
+                                    </div>
+                                </div>
+                                <NewCourseMap lat={req.latitude} lng={req.longitude} />
+                            </>
+                        ) : (
+                            <>
+                                <table className="table table-sm table-borderless mb-2" style={{ fontSize: '0.85rem' }}>
+                                    <tbody>
+                                        <tr>
+                                            <td className="text-muted">Original lat</td>
+                                            <td>{req.original_latitude?.toFixed(6)}</td>
+                                            <td className="text-muted">New lat</td>
+                                            <td>{req.latitude?.toFixed(6)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="text-muted">Original lng</td>
+                                            <td>{req.original_longitude?.toFixed(6)}</td>
+                                            <td className="text-muted">New lng</td>
+                                            <td>{req.longitude?.toFixed(6)}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                {req.original_latitude != null && req.original_longitude != null ? (
+                                    <LocationChangeMap
+                                        origLat={req.original_latitude} origLng={req.original_longitude}
+                                        newLat={req.latitude} newLng={req.longitude}
+                                    />
+                                ) : (
+                                    <NewCourseMap lat={req.latitude} lng={req.longitude} />
+                                )}
+                            </>
+                        )}
+                    </Col>
+                    <Col md={7}>
+                        {req.review_message && (
+                            <Alert variant="secondary" className="mb-2" style={{ fontSize: '0.85rem' }}>
+                                <strong>Admin note:</strong> {req.review_message}
+                            </Alert>
+                        )}
+
+                        {req.status === 'pending' && (
+                            <div className="mt-2">
+                                <div className="d-flex gap-2 mb-2">
+                                    <Button variant="success" size="sm" disabled={busy} onClick={handleApprove}>
+                                        {busy && !rejecting ? <Spinner size="sm" className="me-1" /> : null}
+                                        Approve
+                                    </Button>
+                                    <Button variant="outline-danger" size="sm" disabled={busy} onClick={() => setRejecting(r => !r)}>
+                                        Reject…
+                                    </Button>
+                                </div>
+                                {rejecting && (
+                                    <div>
+                                        <Form.Control
+                                            as="textarea" rows={2} size="sm"
+                                            placeholder="Reason for rejection (required)"
+                                            value={rejectMsg}
+                                            onChange={e => setRejectMsg(e.target.value)}
+                                            className="mb-2"
+                                        />
+                                        <Button variant="danger" size="sm" disabled={busy || !rejectMsg.trim()} onClick={handleReject}>
+                                            {busy ? <Spinner size="sm" className="me-1" /> : null}
+                                            Confirm Reject
+                                        </Button>
+                                        <Button variant="link" size="sm" onClick={() => { setRejecting(false); setRejectMsg(''); }}>
+                                            Cancel
+                                        </Button>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </Col>
+                </Row>
+            </Card.Body>
+        </Card>
+    );
+}
+
+// ── Section (new courses or location changes) ─────────────────────────────────
+
+function RequestSection({ title, type, requests, onAction }) {
+    const filtered = requests.filter(r => r.request_type === type);
+    if (!filtered.length) return <p className="text-muted">No {title.toLowerCase()} at this time.</p>;
+    return (
+        <>
+            <h6 className="mb-3">{title} <Badge bg="secondary" className="ms-1">{filtered.length}</Badge></h6>
+            {filtered.map(r => <RequestCard key={r.id} req={r} onAction={onAction} />)}
+        </>
+    );
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+export default function AdminReviewRequests() {
+    const [requests, setRequests] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [pendingOnly, setPendingOnly] = useState(true);
+    const [error, setError] = useState(null);
+
+    const fetchRequests = (pendingOnlyFlag) => {
+        setLoading(true);
+        setError(null);
+        api.get(`/course-requests/admin/all?pending_only=${pendingOnlyFlag}`)
+            .then(res => setRequests(res.data))
+            .catch(err => setError(err.response?.data?.detail || 'Failed to load requests.'))
+            .finally(() => setLoading(false));
+    };
+
+    useEffect(() => { fetchRequests(pendingOnly); }, [pendingOnly]);
+
+    const handleAction = (id, newStatus) => {
+        setRequests(prev =>
+            pendingOnly
+                ? prev.filter(r => r.id !== id)
+                : prev.map(r => r.id === id ? { ...r, status: newStatus } : r)
+        );
+    };
+
+    return (
+        <div className="p-3">
+            <div className="d-flex justify-content-between align-items-center mb-3">
+                <h4 className="mb-0">Review User Requests</h4>
+                <Form.Check
+                    type="switch"
+                    id="pending-only-toggle"
+                    label="Pending only"
+                    checked={pendingOnly}
+                    onChange={e => setPendingOnly(e.target.checked)}
+                />
+            </div>
+
+            {error && <Alert variant="danger">{error}</Alert>}
+
+            {loading ? (
+                <div className="text-center py-4"><Spinner /> Loading requests…</div>
+            ) : (
+                <Row>
+                    <Col md={6} className="mb-4">
+                        <h5 className="border-bottom pb-2 mb-3">New Course Requests</h5>
+                        <RequestSection title="New Courses" type="new_course" requests={requests} onAction={handleAction} />
+                    </Col>
+                    <Col md={6} className="mb-4">
+                        <h5 className="border-bottom pb-2 mb-3">Location Change Requests</h5>
+                        <RequestSection title="Location Changes" type="location_change" requests={requests} onAction={handleAction} />
+                    </Col>
+                </Row>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/AdminReviewRequests.jsx
+++ b/frontend/src/components/AdminReviewRequests.jsx
@@ -106,6 +106,9 @@ function RequestCard({ req, onAction }) {
                 <span><strong>{courseName}</strong></span>
                 <div className="d-flex align-items-center gap-2">
                     <StatusBadge status={req.status} />
+                    {req.status === 'approved' && req.request_type === 'new_course' && req.approved_course_id && (
+                        <span className="text-muted" style={{ fontSize: '0.8rem' }}>Course ID: {req.approved_course_id}</span>
+                    )}
                     <span className="text-muted" style={{ fontSize: '0.8rem' }}>
                         {req.created_at ? new Date(req.created_at).toLocaleDateString() : ''}
                     </span>

--- a/frontend/src/components/CourseCard.jsx
+++ b/frontend/src/components/CourseCard.jsx
@@ -62,7 +62,13 @@ function CourseCard({ id, display_name, city, state, country, year, onDelete, on
                     </span>
                 )}
             </td>
-            <td>
+            <td style={{ whiteSpace: 'nowrap' }}>
+                <span
+                    title={`Course ID: ${id}`}
+                    style={{ marginRight: '4px', cursor: 'default', color: 'var(--text-muted)', fontSize: '0.75rem', userSelect: 'none' }}
+                >
+                    ❓
+                </span>
                 <button
                     type="button"
                     className="btn-delete-icon"

--- a/frontend/src/components/CourseEdits.jsx
+++ b/frontend/src/components/CourseEdits.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
+import { Spinner, Table, Badge } from 'react-bootstrap';
+import CourseEditsNav from './CourseEditsNav';
+import api from '../services/api';
+
+function StatusBadge({ status }) {
+    const map = { pending: 'warning', approved: 'success', rejected: 'danger' };
+    return <Badge bg={map[status] ?? 'secondary'} text={status === 'pending' ? 'dark' : undefined}>{status}</Badge>;
+}
+
+function MyRequests({ refreshKey }) {
+    const [requests, setRequests] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        setLoading(true);
+        api.get('/course-requests/my-requests')
+            .then(res => setRequests(res.data))
+            .catch(console.error)
+            .finally(() => setLoading(false));
+    }, [refreshKey]);
+
+    if (loading) return <div className="text-center py-3"><Spinner size="sm" className="me-2" />Loading your requests…</div>;
+    if (!requests.length) return <p className="text-muted">No requests submitted yet.</p>;
+
+    return (
+        <Table hover responsive size="sm">
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Course</th>
+                    <th>Submitted</th>
+                    <th>Status</th>
+                    <th>Admin Note</th>
+                </tr>
+            </thead>
+            <tbody>
+                {requests.map(r => (
+                    <tr key={r.id}>
+                        <td>{r.request_type === 'new_course' ? 'New Course' : 'Location Change'}</td>
+                        <td>
+                            {r.request_type === 'new_course'
+                                ? [r.club_name, r.course_name].filter(Boolean).join(' – ') || '—'
+                                : r.course_display_name || `Course #${r.course_id}`}
+                        </td>
+                        <td className="text-nowrap">{r.created_at ? new Date(r.created_at).toLocaleDateString() : '—'}</td>
+                        <td><StatusBadge status={r.status} /></td>
+                        <td className="text-muted" style={{ fontSize: '0.85rem' }}>{r.review_message || '—'}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    );
+}
+
+export default function CourseEditsLayout() {
+    const [refreshKey, setRefreshKey] = useState(0);
+    const onSubmitted = () => setRefreshKey(k => k + 1);
+
+    return (
+        <>
+            <CourseEditsNav />
+            <div className="p-3">
+                <Outlet context={{ onSubmitted }} />
+
+                <hr />
+                <h5 className="mb-3">My Requests</h5>
+                <MyRequests refreshKey={refreshKey} />
+            </div>
+        </>
+    );
+}

--- a/frontend/src/components/CourseEditsLocationChange.jsx
+++ b/frontend/src/components/CourseEditsLocationChange.jsx
@@ -1,0 +1,166 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { MapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Form, Button, Row, Col, Alert, Spinner, Card } from 'react-bootstrap';
+import api from '../services/api';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+const DEFAULT_CENTER = [39, -98];
+
+function FlyTo({ target }) {
+    const map = useMap();
+    useEffect(() => { if (target) map.flyTo(target, 14); }, [target, map]);
+    return null;
+}
+
+function DraggableMarker({ position, setPosition }) {
+    const markerRef = useRef(null);
+    const eventHandlers = { dragend() { const m = markerRef.current; if (m) setPosition(m.getLatLng()); } };
+    return <Marker draggable position={position} eventHandlers={eventHandlers} ref={markerRef} />;
+}
+
+function MapClickHandler({ setPosition }) {
+    useMapEvents({ click(e) { setPosition(e.latlng); } });
+    return null;
+}
+
+export default function CourseEditsLocationChange() {
+    const { onSubmitted } = useOutletContext();
+    const [courseId, setCourseId] = useState('');
+    const [course, setCourse] = useState(null);
+    const [position, setPosition] = useState(null);
+    const [flyTarget, setFlyTarget] = useState(null);
+    const [loadAlert, setLoadAlert] = useState(null);
+    const [submitAlert, setSubmitAlert] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    const handleLoad = async e => {
+        e.preventDefault();
+        if (!courseId) return;
+        setLoading(true);
+        setLoadAlert(null);
+        setCourse(null);
+        setSubmitAlert(null);
+        setSubmitted(false);
+        try {
+            const res = await api.get(`/garmin_courses/course/${courseId}`);
+            const c = res.data;
+            setCourse(c);
+            const pos = Number.isFinite(c.latitude) && Number.isFinite(c.longitude)
+                ? { lat: c.latitude, lng: c.longitude }
+                : null;
+            setPosition(pos);
+            setFlyTarget(pos);
+        } catch (err) {
+            setLoadAlert(err.response?.status === 404 ? `Course ID ${courseId} not found.` : 'Failed to load course.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSubmit = async e => {
+        e.preventDefault();
+        if (!course || !position) return;
+        setSaving(true);
+        setSubmitAlert(null);
+        try {
+            await api.post('/course-requests/location-change', {
+                course_id: course.id,
+                latitude: position.lat ?? position[0],
+                longitude: position.lng ?? position[1],
+            });
+            setSubmitted(true);
+            onSubmitted();
+        } catch (err) {
+            const detail = err.response?.data?.detail || 'Failed to submit request.';
+            setSubmitAlert({ variant: err.response?.status === 409 ? 'warning' : 'danger', msg: detail });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const lat = position ? (position.lat ?? position[0]) : null;
+    const lng = position ? (position.lng ?? position[1]) : null;
+
+    return (
+        <>
+            <h5 className="mb-3">Request Location Change</h5>
+            <Form onSubmit={handleLoad} className="mb-3">
+                <Row className="align-items-end g-2">
+                    <Col xs="auto">
+                        <Form.Label>Course ID</Form.Label>
+                        <Form.Control
+                            type="number" min="1" value={courseId}
+                            onChange={e => setCourseId(e.target.value)}
+                            placeholder="Enter course ID" style={{ width: '160px' }}
+                        />
+                    </Col>
+                    <Col xs="auto">
+                        <Button type="submit" variant="secondary" disabled={loading || !courseId}>
+                            {loading ? <><Spinner size="sm" className="me-1" />Loading…</> : 'Load Course'}
+                        </Button>
+                    </Col>
+                </Row>
+                {loadAlert && <Alert variant="warning" className="mt-2 mb-0">{loadAlert}</Alert>}
+            </Form>
+
+            {course && !submitted && (
+                <>
+                    <Card className="mb-3">
+                        <Card.Body className="py-2">
+                            <strong>{course.display_name}</strong>
+                            <span className="text-muted ms-2">{[course.city, course.state, course.country].filter(Boolean).join(', ')}</span>
+                        </Card.Body>
+                    </Card>
+
+                    {submitAlert && <Alert variant={submitAlert.variant} dismissible onClose={() => setSubmitAlert(null)}>{submitAlert.msg}</Alert>}
+
+                    <p className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>
+                        Drag the marker or click anywhere on the map to propose a new location.
+                    </p>
+                    <Row>
+                        <Col md={9}>
+                            <MapContainer center={position ? [lat, lng] : DEFAULT_CENTER} zoom={position ? 14 : 4} style={{ height: '460px', width: '100%', borderRadius: '6px' }}>
+                                <TileLayer attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+                                <FlyTo target={flyTarget} />
+                                <MapClickHandler setPosition={setPosition} />
+                                {position && <DraggableMarker position={position} setPosition={setPosition} />}
+                            </MapContainer>
+                        </Col>
+                        <Col md={3} className="d-flex flex-column justify-content-center">
+                            <div className="mb-3">
+                                <div className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>Proposed coordinates</div>
+                                <div><strong>Lat:</strong> {lat?.toFixed(6)}</div>
+                                <div><strong>Lng:</strong> {lng?.toFixed(6)}</div>
+                            </div>
+                            <Button variant="primary" onClick={handleSubmit} disabled={saving || !position}>
+                                {saving ? <><Spinner size="sm" className="me-1" />Submitting…</> : 'Submit Location Change'}
+                            </Button>
+                        </Col>
+                    </Row>
+                </>
+            )}
+
+            {submitted && (
+                <Alert variant="info" className="mt-3">
+                    <strong>Request submitted!</strong> An admin will review your location change shortly. Check the table below for status updates.
+                    <div className="mt-2">
+                        <Button variant="outline-info" size="sm" onClick={() => { setSubmitted(false); setCourse(null); setCourseId(''); setPosition(null); }}>
+                            Submit another
+                        </Button>
+                    </div>
+                </Alert>
+            )}
+        </>
+    );
+}

--- a/frontend/src/components/CourseEditsNav.jsx
+++ b/frontend/src/components/CourseEditsNav.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const navLinkClass = ({ isActive }) =>
+    `admin-nav-link${isActive ? ' active' : ''}`;
+
+const CourseEditsNav = () => (
+    <nav className="admin-topnav" style={{ display: 'flex', alignItems: 'center' }}>
+        <NavLink to="/course_edits/new-course" className={navLinkClass}>
+            Request New Course
+        </NavLink>
+        <NavLink to="/course_edits/location-change" className={navLinkClass}>
+            Request Location Change
+        </NavLink>
+        <span className="ms-auto me-3 text-muted" style={{ fontSize: '0.8rem', whiteSpace: 'nowrap' }}>
+            Requests are reviewed by an admin before taking effect
+        </span>
+    </nav>
+);
+
+export default CourseEditsNav;

--- a/frontend/src/components/CourseEditsNewCourse.jsx
+++ b/frontend/src/components/CourseEditsNewCourse.jsx
@@ -1,0 +1,141 @@
+import React, { useState, useRef } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Form, Button, Row, Col, Alert, Spinner } from 'react-bootstrap';
+import api from '../services/api';
+import { nominatimToGeoFields } from '../utils/geoLookup';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({ iconUrl: markerIcon, iconRetinaUrl: markerIcon2x, shadowUrl: markerShadow });
+
+const EMPTY_FORM = { club_name: '', course_name: '', address: '', city: '', state: '', country: '' };
+
+function LocationPicker({ position, setPosition, setForm }) {
+    const abortRef = useRef(null);
+    useMapEvents({
+        click(e) {
+            const { lat, lng } = e.latlng;
+            setPosition([lat, lng]);
+            if (abortRef.current) abortRef.current.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+            fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`, { signal: controller.signal })
+                .then(r => r.json())
+                .then(data => {
+                    const a = data.address || {};
+                    const { city, state, country } = nominatimToGeoFields(a);
+                    setForm(prev => ({
+                        ...prev,
+                        city,
+                        state,
+                        country,
+                        address: a.road ? `${a.house_number ? a.house_number + ' ' : ''}${a.road}` : '',
+                    }));
+                })
+                .catch(err => { if (err.name !== 'AbortError') console.error(err); });
+        },
+    });
+    return position ? <Marker position={position} /> : null;
+}
+
+export default function CourseEditsNewCourse() {
+    const { onSubmitted } = useOutletContext();
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [position, setPosition] = useState(null);
+    const [alert, setAlert] = useState(null);
+    const [saving, setSaving] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    const handleField = e => setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
+
+    const handleSubmit = async e => {
+        e.preventDefault();
+        if (!position) { setAlert({ variant: 'warning', msg: 'Click the map to set a location first.' }); return; }
+        setSaving(true);
+        setAlert(null);
+        try {
+            await api.post('/course-requests/new-course', {
+                ...form,
+                latitude: position[0],
+                longitude: position[1],
+            });
+            setSubmitted(true);
+            onSubmitted();
+        } catch (err) {
+            setAlert({ variant: 'danger', msg: err.response?.data?.detail || 'Failed to submit request.' });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (submitted) {
+        return (
+            <Alert variant="info" className="mt-3">
+                <strong>Request submitted!</strong> An admin will review your new course shortly. Check the table below for status updates.
+                <div className="mt-2">
+                    <Button variant="outline-info" size="sm" onClick={() => { setSubmitted(false); setForm(EMPTY_FORM); setPosition(null); }}>
+                        Submit another
+                    </Button>
+                </div>
+            </Alert>
+        );
+    }
+
+    return (
+        <>
+            <h5 className="mb-3">Request New Course</h5>
+            {alert && <Alert variant={alert.variant} dismissible onClose={() => setAlert(null)}>{alert.msg}</Alert>}
+            <Row>
+                <Col md={5}>
+                    <Form onSubmit={handleSubmit}>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Club Name</Form.Label>
+                            <Form.Control name="club_name" value={form.club_name} onChange={handleField} placeholder="e.g. Augusta National" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Course Name</Form.Label>
+                            <Form.Control name="course_name" value={form.course_name} onChange={handleField} placeholder="e.g. Championship Course" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>Address</Form.Label>
+                            <Form.Control name="address" value={form.address} onChange={handleField} placeholder="Street address" />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>City</Form.Label>
+                            <Form.Control name="city" value={form.city} onChange={handleField} />
+                        </Form.Group>
+                        <Form.Group className="mb-2">
+                            <Form.Label>State / Province</Form.Label>
+                            <Form.Control name="state" value={form.state} onChange={handleField} />
+                        </Form.Group>
+                        <Form.Group className="mb-3">
+                            <Form.Label>Country</Form.Label>
+                            <Form.Control name="country" value={form.country} onChange={handleField} />
+                        </Form.Group>
+                        <div className="mb-3 text-muted" style={{ fontSize: '0.9rem' }}>
+                            {position
+                                ? <><strong>Lat:</strong> {position[0].toFixed(6)} &nbsp; <strong>Lng:</strong> {position[1].toFixed(6)}</>
+                                : 'Click the map to set coordinates'}
+                        </div>
+                        <Button type="submit" variant="primary" disabled={saving || !position}>
+                            {saving ? <><Spinner size="sm" className="me-1" />Submitting…</> : 'Submit Request'}
+                        </Button>
+                    </Form>
+                </Col>
+                <Col md={7}>
+                    <p className="text-muted mb-1" style={{ fontSize: '0.85rem' }}>Click anywhere on the map to set the course location. Address fields will auto-fill.</p>
+                    <MapContainer center={[39, -98]} zoom={4} style={{ height: '480px', width: '100%', borderRadius: '6px' }}>
+                        <TileLayer attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>' url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+                        <LocationPicker position={position} setPosition={setPosition} setForm={setForm} />
+                    </MapContainer>
+                </Col>
+            </Row>
+        </>
+    );
+}

--- a/frontend/src/components/CourseEditsNewCourse.jsx
+++ b/frontend/src/components/CourseEditsNewCourse.jsx
@@ -99,7 +99,7 @@ export default function CourseEditsNewCourse() {
                             <Form.Control name="club_name" value={form.club_name} onChange={handleField} placeholder="e.g. Augusta National" />
                         </Form.Group>
                         <Form.Group className="mb-2">
-                            <Form.Label>Course Name</Form.Label>
+                            <Form.Label>Course Name <span className="text-muted" style={{ fontSize: '0.85em' }}>(Optional)</span></Form.Label>
                             <Form.Control name="course_name" value={form.course_name} onChange={handleField} placeholder="e.g. Championship Course" />
                         </Form.Group>
                         <Form.Group className="mb-2">

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -34,8 +34,8 @@ function Header({ isOpen, onClose }) {
                 <NavLink to="/course_search" className={navLinkClass} onClick={onClose}>
                     <span className="nav-icon">🔍</span> Course Search
                 </NavLink>
-                <NavLink to="/add_course_by_id" className={navLinkClass} onClick={onClose}>
-                    <span className="nav-icon">➕</span> Add Course
+                <NavLink to="/course_edits" className={navLinkClass} onClick={onClose}>
+                    <span className="nav-icon">✏️</span> Course Edits
                 </NavLink>
                 {userRole === 'admin' && (
                     <NavLink to="/admin/users" className={navLinkClass} onClick={onClose}>

--- a/frontend/src/components/Map.jsx
+++ b/frontend/src/components/Map.jsx
@@ -8,12 +8,10 @@ function Map() {
     const { token } = useAuth();
     const [status, setStatus] = useState('loading');
 
-    const loadMap = useCallback(async () => {
-        const callId = {};
-        activeCallRef.current = callId;
+    const renderMap = useCallback(async (callId, forceGenerate = false) => {
         const isCurrent = () => activeCallRef.current === callId;
 
-        setStatus('loading');
+        setStatus(forceGenerate ? 'generating' : 'loading');
         try {
             const coursesRes = await api.get('/user_courses/readall_ids_w_year');
             if (!isCurrent()) return;
@@ -27,6 +25,11 @@ function Map() {
         }
 
         try {
+            if (forceGenerate) {
+                await api.get('/map/user_map_generate');
+                if (!isCurrent()) return;
+            }
+
             let response;
             try {
                 response = await api.get('/map/usermap?rand=' + new Date());
@@ -52,13 +55,25 @@ function Map() {
         }
     }, []);
 
+    const loadMap = useCallback(() => {
+        const callId = {};
+        activeCallRef.current = callId;
+        renderMap(callId, false);
+    }, [renderMap]);
+
+    const regenerateMap = useCallback(() => {
+        const callId = {};
+        activeCallRef.current = callId;
+        renderMap(callId, true);
+    }, [renderMap]);
+
     useEffect(() => { loadMap(); }, [token, loadMap]);
 
     return (
         <div className="map-wrapper">
             <div className="map-overlay-bar">
                 <div className="map-title-chip">🗺 Your Golf Map</div>
-                <button className="btn-ghost" onClick={loadMap}>
+                <button className="btn-ghost" onClick={regenerateMap}>
                     ⟳ Regenerate Map
                 </button>
             </div>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createBrowserRouter, Outlet, Link } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet, Link } from 'react-router-dom';
 import CourseList from './components/CourseList';
 import CourseForm from './components/CourseForm';
 import Map from './components/Map';
@@ -13,6 +13,10 @@ import UserProfile from './components/UserProfile';
 import AdminUsers from './components/AdminUsers';
 import AdminAddCourse from './components/AdminAddCourse';
 import AdminEditCourse from './components/AdminEditCourse';
+import AdminReviewRequests from './components/AdminReviewRequests';
+import CourseEdits from './components/CourseEdits';
+import CourseEditsNewCourse from './components/CourseEditsNewCourse';
+import CourseEditsLocationChange from './components/CourseEditsLocationChange';
 import ForgotPassword from './components/ForgotPassword';
 import ResetPassword from './components/ResetPassword';
 
@@ -35,6 +39,15 @@ const router = createBrowserRouter([
             { path: '/all_map', element: <AllUsersMap /> },
             { path: '/course_search', element: <CourseSearch /> },
             { path: '/profile', element: <UserProfile /> },
+            {
+                path: '/course_edits',
+                element: <CourseEdits />,
+                children: [
+                    { index: true, element: <Navigate to="new-course" replace /> },
+                    { path: 'new-course', element: <CourseEditsNewCourse /> },
+                    { path: 'location-change', element: <CourseEditsLocationChange /> },
+                ],
+            },
         ],
     },
     {
@@ -43,6 +56,7 @@ const router = createBrowserRouter([
             { path: '/admin/users', element: <AdminUsers /> },
             { path: '/admin/add-course', element: <AdminAddCourse /> },
             { path: '/admin/edit-course', element: <AdminEditCourse /> },
+            { path: '/admin/review-requests', element: <AdminReviewRequests /> },
         ],
     },
     {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -14,6 +14,7 @@ import AdminUsers from './components/AdminUsers';
 import AdminAddCourse from './components/AdminAddCourse';
 import AdminEditCourse from './components/AdminEditCourse';
 import AdminReviewRequests from './components/AdminReviewRequests';
+import AdminEditCourseInfo from './components/AdminEditCourseInfo';
 import CourseEdits from './components/CourseEdits';
 import CourseEditsNewCourse from './components/CourseEditsNewCourse';
 import CourseEditsLocationChange from './components/CourseEditsLocationChange';
@@ -56,6 +57,7 @@ const router = createBrowserRouter([
             { path: '/admin/users', element: <AdminUsers /> },
             { path: '/admin/add-course', element: <AdminAddCourse /> },
             { path: '/admin/edit-course', element: <AdminEditCourse /> },
+            { path: '/admin/edit-course-info', element: <AdminEditCourseInfo /> },
             { path: '/admin/review-requests', element: <AdminReviewRequests /> },
         ],
     },


### PR DESCRIPTION
## Summary

- Users can submit new course requests and location change requests via a new **Course Edits** page (top nav with two tabs); requests queue for admin review instead of writing directly to the DB
- Admins get a new **Review Requests** page with inline Leaflet maps — single marker for new courses, blue/red before-after markers for location changes — plus approve and reject-with-message controls
- Approved new-course requests auto-add the course to the submitting user played-courses list; duplicate pending location-change requests for the same course are blocked (409)
- `CourseRequests` DB model added; `course_requests` router with 6 endpoints wired into `main.py`
- Sidebar "Add Course" link replaced by "Course Edits" for all users
- Course ID tooltip added before the delete button on My Courses
- 15 new backend tests covering submit, duplicate block, approve, reject, and access control — 36/36 passing

## Test plan

- [ ] Log in as a regular user, navigate to Course Edits → Request New Course, fill form, click map, submit — confirm success alert and entry in My Requests with pending status
- [ ] Submit a second location-change request for the same course while one is pending — confirm duplicate-blocked warning
- [ ] Log in as admin, navigate to Admin → Review Requests — confirm new course card shows single marker, location change card shows blue/red before-after markers
- [ ] Approve a new course request — confirm course appears in DB and in submitting user My Courses list
- [ ] Reject a request with a message — confirm rejected status and message appear in user My Requests table
- [ ] Toggle "Pending only" switch — confirm approved/rejected history appears
- [ ] Hover the ? on My Courses — confirm course ID tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course request system allowing users to submit new courses and propose location changes
  * Admins can review, approve, or reject pending requests with optional notes
  * Users can track submitted requests with status updates
  * Map-based interface for specifying course locations

* **Navigation Updates**
  * Added "Course Edits" link to main navigation
  * Added "Review Requests" link to admin panel
  * Added course ID indicator in course listings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeorgeBronner/golfmapper3/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->