### PR TITLE
Return 409 when user adds a duplicate course/year entry

### DIFF
--- a/backend/app/routers/user_courses.py
+++ b/backend/app/routers/user_courses.py
@@ -3,6 +3,7 @@ from pathlib import Path as FilePath
 
 from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.exc import IntegrityError
 from starlette import status
 
 from app.config import settings
@@ -117,7 +118,11 @@ async def add_user_course(user: user_dependency, db: db_dependency, user_course_
         user_id=user.get("id"),
     )
     db.add(user_course_model)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Course already logged for this year")
     _invalidate_user_map(user.get("id"))
 
 

--- a/backend/tests/test_user_courses.py
+++ b/backend/tests/test_user_courses.py
@@ -38,6 +38,12 @@ def test_read_one_authenticated(test_user_courses):
     ]
 
 
+def test_add_course_duplicate_returns_409(test_user_courses):
+    response = client.post("/api/v1/user_courses/add_course", json={"garmin_id": 200, "year": 2021})
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "already logged" in response.json()["detail"]
+
+
 def test_readall_ids_w_year_datetime_created_at(test_user_courses_with_datetime):
     # Regression: CourseResponse.created_at must accept datetime objects, not just str.
     # A str type annotation caused Pydantic v2 to raise string_type validation errors


### PR DESCRIPTION
## Summary

- Catches `IntegrityError` on `POST /api/v1/user_courses/add_course` and returns **409 Conflict** instead of crashing with a 500
- Rolls back the DB transaction cleanly before raising
- Adds a regression test covering the duplicate add path

## Root cause

The `user_courses` table has a UNIQUE constraint on `(user_id, course_id, year)`. When a user tried to log the same course for a year they'd already recorded, SQLite raised an `IntegrityError` that propagated unhandled through Starlette, producing a 500. The frontend `CourseForm` already handled 409 correctly — it just never received one.

## Test plan

- [ ] `uv run python -m pytest tests/test_user_courses.py -v` — all 4 tests pass
- [ ] Manually try adding a course for a year already logged — should show "You have already added this course for that year."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for duplicate course entries. When attempting to add a course that's already been logged for the same year, users now receive a clear, informative error message instead of a system failure, providing better feedback during course management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeorgeBronner/golfmapper3/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->