### PR TITLE
Remove host port binding from gm3-backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: gm3-backend
-    ports:
-      - "8005:8005"
     volumes:
       - type: bind
         source: ${DB_PATH:-./backend/golf_mapper.db}


### PR DESCRIPTION
## Summary

- Removes `ports: - "8005:8005"` from `docker-compose.yml`

## Why

The backend sits behind NPM on the `nginx-proxy` Docker network — NPM proxies `golf.bronnerapp.com` to the container directly over that network. Exposing port 8005 on the host bypassed NPM entirely, allowing direct unauthenticated API access from any host that could reach oracle on that port.

This was already removed live on oracle as part of the 2026-05-25 security hardening (OCI firewall tightening + port binding cleanup). This PR syncs the repo to match what's running.

## Test plan

- [ ] No functional change — NPM continues to proxy correctly via `nginx-proxy` network
- [ ] Confirm `docker ps` on oracle does not show `0.0.0.0:8005->8005/tcp` after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)