### PR TITLE
Fix three production errors from Sentry

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from starlette import status
 
 from app.dependencies import db_dependency, user_dependency
-from app.models import CourseRequests, Courses, Users
+from app.models import CourseRequests, Courses, UserCourses, Users
 from app.routers.garmin_courses import CourseBase
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -77,6 +77,7 @@ async def delete_course(user: user_dependency, db: db_dependency, course_id: int
     course_model = db.query(Courses).filter(Courses.id == course_id).first()
     if course_model is None:
         raise HTTPException(status_code=404, detail="Course not found")
+    db.query(UserCourses).filter(UserCourses.course_id == course_id).delete(synchronize_session=False)
     db.query(CourseRequests).filter(
         (CourseRequests.course_id == course_id) |
         (CourseRequests.approved_course_id == course_id),

--- a/backend/app/routers/map.py
+++ b/backend/app/routers/map.py
@@ -29,6 +29,8 @@ async def generate_user_map(user: dict, db) -> Path:
     if user_courses:
         fg = folium.FeatureGroup(name=user['username'])
         for course in user_courses:
+            if course.latitude is None or course.longitude is None:
+                continue
             description = course.display_name + ' ' + str(course.id)
             fg.add_child(
                 folium.CircleMarker(

--- a/backend/app/routers/user_courses.py
+++ b/backend/app/routers/user_courses.py
@@ -105,7 +105,15 @@ async def readall(user: user_dependency, db: db_dependency):
         .all()
     )
     course_ids = [course_id for course_id, in course_ids]
-    return db.query(Courses).filter(Courses.id.in_(course_ids)).all()
+    return (
+        db.query(Courses)
+        .filter(
+            Courses.id.in_(course_ids),
+            Courses.latitude.isnot(None),
+            Courses.longitude.isnot(None),
+        )
+        .all()
+    )
 
 
 @router.post("/add_course", status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Summary

- **IntegrityError on course delete** (`admin.py`): Explicitly delete `user_courses` rows before deleting a course. SQLAlchemy's ORM cascade was trying to SET NULL on the `course_id` FK before firing the delete, hitting the NOT NULL constraint.
- **ResponseValidationError on `/readall`** (`user_courses.py`): Added null lat/lng filter to the `readall` query. `readall_ids_w_year` already had this filter; `readall` didn't, causing FastAPI to fail serialising courses with `None` coordinates into the `CourseResponse` model (which requires `float`).
- **ValueError in map generation** (`map.py`): Added a null coordinate guard in `generate_user_map` so folium never receives `None` lat/lng values. The `readall` fix is the primary fix; this is defence-in-depth.

Identified via Sentry issues GOLFMAPPER3-K, GOLFMAPPER3-N, and GOLFMAPPER3-P.

## Test plan

- [ ] All 42 existing backend tests pass (`uv run pytest`)
- [ ] Delete a course that has associated user records — should succeed with no 500
- [ ] Load the course list for a user who has a course with missing coordinates — should return cleanly without a validation error
- [ ] Generate a user map when a course is missing coordinates — map generates successfully, skipping the incomplete course

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map generation to gracefully handle courses with missing location data.
  * Enhanced course listing to filter out entries lacking geographic coordinates.
  * Fixed course deletion process to properly clean up all associated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->